### PR TITLE
Update Player death event with javadocs + ActionResult instead of bools

### DIFF
--- a/src/main/java/xyz/nucleoid/plasmid/game/GameWorld.java
+++ b/src/main/java/xyz/nucleoid/plasmid/game/GameWorld.java
@@ -128,6 +128,12 @@ public final class GameWorld implements AutoCloseable {
         return this.bubble.getPlayers();
     }
 
+    /**
+     * Returns whether this {@link GameWorld} contains the given {@link ServerPlayerEntity}.
+     *
+     * @param player  {@link ServerPlayerEntity} to check existence of
+     * @return        whether the given {@link ServerPlayerEntity} exists in this {@link GameWorld}
+     */
     public boolean containsPlayer(ServerPlayerEntity player) {
         return this.bubble.getPlayers().contains(player);
     }

--- a/src/main/java/xyz/nucleoid/plasmid/game/event/PlayerDeathListener.java
+++ b/src/main/java/xyz/nucleoid/plasmid/game/event/PlayerDeathListener.java
@@ -2,18 +2,31 @@ package xyz.nucleoid.plasmid.game.event;
 
 import net.minecraft.entity.damage.DamageSource;
 import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.util.ActionResult;
 
+/**
+ * Called when any {@link ServerPlayerEntity} is killed in a {@link xyz.nucleoid.plasmid.game.GameWorld}.
+ *
+ * <p>Upon return:
+ * <ul>
+ * <li>{@link ActionResult#SUCCESS} cancels further processing and kills the player.
+ * <li>{@link ActionResult#FAIL} cancels further processing and does not kill the player.
+ * <li>{@link ActionResult#PASS} moves on to the next listener.</ul>
+ *
+ * If all listeners return {@link ActionResult#PASS}, the player is killed.
+ */
 public interface PlayerDeathListener {
-    EventType<PlayerDeathListener> EVENT = EventType.create(PlayerDeathListener.class, listeners -> {
-        return (player, source) -> {
-            for (PlayerDeathListener listener : listeners) {
-                if (listener.onDeath(player, source)) {
-                    return true;
-                }
+    EventType<PlayerDeathListener> EVENT = EventType.create(PlayerDeathListener.class, listeners -> (player, source) -> {
+        for (PlayerDeathListener listener : listeners) {
+            ActionResult result = listener.onDeath(player, source);
+
+            if(result != ActionResult.PASS) {
+                return result;
             }
-            return false;
-        };
+        }
+
+        return ActionResult.PASS;
     });
 
-    boolean onDeath(ServerPlayerEntity player, DamageSource source);
+    ActionResult onDeath(ServerPlayerEntity player, DamageSource source);
 }

--- a/src/main/java/xyz/nucleoid/plasmid/mixin/event/ServerPlayerEntityMixin.java
+++ b/src/main/java/xyz/nucleoid/plasmid/mixin/event/ServerPlayerEntityMixin.java
@@ -1,5 +1,6 @@
 package xyz.nucleoid.plasmid.mixin.event;
 
+import net.minecraft.util.ActionResult;
 import xyz.nucleoid.plasmid.game.GameWorld;
 import xyz.nucleoid.plasmid.game.event.PlayerDamageListener;
 import xyz.nucleoid.plasmid.game.event.PlayerDeathListener;
@@ -22,8 +23,9 @@ public class ServerPlayerEntityMixin {
 
         GameWorld gameWorld = GameWorld.forWorld(player.world);
         if (gameWorld != null && gameWorld.containsPlayer(player)) {
-            boolean cancel = gameWorld.invoker(PlayerDeathListener.EVENT).onDeath(player, source);
-            if (cancel) {
+            ActionResult result = gameWorld.invoker(PlayerDeathListener.EVENT).onDeath(player, source);
+
+            if(result == ActionResult.FAIL) {
                 ci.cancel();
             }
         }


### PR DESCRIPTION
PR that updates the Player Death Event with JavaDocs, and makes it use ActionResult (which makes it much more intuitive/useable).

I also noticed some of the listeners could be shortened with lambdas (which I did here). Is this intentional, or am I fine condensing it down? 