### PR TITLE
Add entity drop loot event

### DIFF
--- a/src/main/java/xyz/nucleoid/plasmid/game/event/EntityDropLootListener.java
+++ b/src/main/java/xyz/nucleoid/plasmid/game/event/EntityDropLootListener.java
@@ -1,0 +1,40 @@
+package xyz.nucleoid.plasmid.game.event;
+
+import net.minecraft.entity.LivingEntity;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.ActionResult;
+import net.minecraft.util.TypedActionResult;
+
+import java.util.List;
+
+/**
+ * Called when any {@link net.minecraft.entity.LivingEntity} drops loot in a {@link xyz.nucleoid.plasmid.game.GameWorld}.
+ *
+ * <p>Upon return:
+ * <ul>
+ * <li>{@link ActionResult#SUCCESS} cancels further processing and drops the current loot.
+ * <li>{@link ActionResult#FAIL} cancels further processing and drops no loot.
+ * <li>{@link ActionResult#PASS} moves on to the next listener.</ul>
+ *
+ * Listeners can modify the list of {@link ItemStack}s returned to them, regardless of what their result is.
+ * If all listeners return {@link ActionResult#PASS}, the current loot is dropped.
+ */
+public interface EntityDropLootListener {
+    EventType<EntityDropLootListener> EVENT = EventType.create(EntityDropLootListener.class, listeners -> (dropper, loot) -> {
+        for (EntityDropLootListener listener : listeners) {
+            TypedActionResult<List<ItemStack>> result = listener.onDropLoot(dropper, loot);
+
+            // modify loot from listener (some may want to pass while still modifying loot)
+            loot = result.getValue();
+
+            // cancel early if success or fail was returned by the listener
+            if (result.getResult() != ActionResult.PASS) {
+                return result;
+            }
+        }
+
+        return TypedActionResult.pass(loot);
+    });
+
+    TypedActionResult<List<ItemStack>> onDropLoot(LivingEntity dropper, List<ItemStack> loot);
+}

--- a/src/main/java/xyz/nucleoid/plasmid/mixin/event/LivingEntityMixin.java
+++ b/src/main/java/xyz/nucleoid/plasmid/mixin/event/LivingEntityMixin.java
@@ -1,17 +1,33 @@
 package xyz.nucleoid.plasmid.mixin.event;
 
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.EntityType;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.damage.DamageSource;
+import net.minecraft.item.ItemStack;
+import net.minecraft.loot.LootTable;
+import net.minecraft.loot.context.LootContext;
 import net.minecraft.util.ActionResult;
+import net.minecraft.util.TypedActionResult;
+import net.minecraft.world.World;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import xyz.nucleoid.plasmid.game.GameWorld;
 import xyz.nucleoid.plasmid.game.event.EntityDeathListener;
+import xyz.nucleoid.plasmid.game.event.EntityDropLootListener;
+
+import java.util.List;
+import java.util.function.Consumer;
 
 @Mixin(LivingEntity.class)
-public class LivingEntityMixin {
+public abstract class LivingEntityMixin extends Entity {
+    private LivingEntityMixin(EntityType<?> type, World world) {
+        super(type, world);
+    }
+
     @Inject(method = "onDeath", at = @At("HEAD"), cancellable = true)
     private void callDeathListener(DamageSource source, CallbackInfo ci) {
         LivingEntity entity = (LivingEntity) (Object) this;
@@ -31,5 +47,32 @@ public class LivingEntityMixin {
                 ci.cancel();
             }
         }
+    }
+
+    @Redirect(method = "dropLoot", at = @At(value = "INVOKE", target = "Lnet/minecraft/loot/LootTable;generateLoot(Lnet/minecraft/loot/context/LootContext;Ljava/util/function/Consumer;)V"))
+    private void modifyDroppedLoot(LootTable lootTable, LootContext context, Consumer<ItemStack> lootConsumer) {
+        List<ItemStack> droppedStacks = lootTable.generateLoot(context);
+
+        // default stack dropping for client
+        if (world.isClient) {
+            droppedStacks.forEach(this::dropStack);
+            return;
+        }
+
+        GameWorld gameWorld = GameWorld.forWorld(world);
+
+        if(gameWorld != null && gameWorld.containsEntity((LivingEntity) (Object) this)) {
+            TypedActionResult<List<ItemStack>> result = gameWorld.invoker(EntityDropLootListener.EVENT).onDropLoot((LivingEntity) (Object) this, droppedStacks);
+
+            // drop potentially modified stacks from listeners
+            if(result.getResult() != ActionResult.FAIL) {
+                result.getValue().forEach(this::dropStack);
+            }
+
+            return;
+        }
+
+        // default stack dropping for non-gameworld on server
+        droppedStacks.forEach(this::dropStack);
     }
 }


### PR DESCRIPTION
This is a simple event that is called when an Entity drops loot.

The primary issue with this is how an entity actually drops loot (`LivingEntity#dropLoot`):
```java
public void dropLoot(DamageSource source, boolean causedByPlayer) {
      Identifier identifier = this.getLootTable();
      LootTable lootTable = this.world.getServer().getLootManager().getTable(identifier);
      LootContext.Builder builder = this.getLootContextBuilder(causedByPlayer, source);
      lootTable.generateLoot(builder.build(LootContextTypes.ENTITY), this::dropStack);
}
```
`generateLoot` takes in a consumer saying "drop this stack," which is called for each item obtained by the loot table. This makes it difficult to modify the output because you either have to replace the consumer, or inject into `dropStack` (which is used for other unrelated mechanics that might break, like Boats dropping Boat items when they die).

I instead opted to redirect `generateLoot`. All drops are collected into a List, and then listeners are asked whether the event should proceed (and if the loot should be modified at all). Vanilla-world / client-worlds fall back to default behavior.