### PR TITLE
Add PlayerChatListener

### DIFF
--- a/src/main/java/xyz/nucleoid/plasmid/game/event/PlayerChatListener.java
+++ b/src/main/java/xyz/nucleoid/plasmid/game/event/PlayerChatListener.java
@@ -15,10 +15,10 @@ import net.minecraft.util.ActionResult;
  * </ul>
  *
  */
-public interface BroadcastChatMessageListener {
-    EventType<BroadcastChatMessageListener> EVENT = EventType.create(BroadcastChatMessageListener.class, listeners -> (message, sender) -> {
-        for (BroadcastChatMessageListener listener : listeners) {
-            ActionResult result = listener.onBroadcastChatMessage(message, sender);
+public interface PlayerChatListener {
+    EventType<PlayerChatListener> EVENT = EventType.create(PlayerChatListener.class, listeners -> (message, sender) -> {
+        for (PlayerChatListener listener : listeners) {
+            ActionResult result = listener.onSendChatMessage(message, sender);
 
             if (result != ActionResult.PASS) {
                 return result;
@@ -28,5 +28,5 @@ public interface BroadcastChatMessageListener {
         return ActionResult.PASS;
     });
 
-    ActionResult onBroadcastChatMessage(Text message, ServerPlayerEntity sender);
+    ActionResult onSendChatMessage(Text message, ServerPlayerEntity sender);
 }

--- a/src/main/java/xyz/nucleoid/plasmid/mixin/chat/PlayerManagerMixin.java
+++ b/src/main/java/xyz/nucleoid/plasmid/mixin/chat/PlayerManagerMixin.java
@@ -16,7 +16,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import xyz.nucleoid.plasmid.chat.ChatChannel;
 import xyz.nucleoid.plasmid.chat.HasChatChannel;
 import xyz.nucleoid.plasmid.game.GameWorld;
-import xyz.nucleoid.plasmid.game.event.BroadcastChatMessageListener;
+import xyz.nucleoid.plasmid.game.event.PlayerChatListener;
 import xyz.nucleoid.plasmid.game.rule.GameRule;
 import xyz.nucleoid.plasmid.game.rule.RuleResult;
 
@@ -44,7 +44,7 @@ public abstract class PlayerManagerMixin {
             return;
         } else {
             GameWorld gameWorld = GameWorld.forWorld(sender.world);
-            if (gameWorld != null && gameWorld.containsEntity(sender) && gameWorld.invoker(BroadcastChatMessageListener.EVENT).onBroadcastChatMessage(message, sender) == ActionResult.FAIL) {
+            if (gameWorld != null && gameWorld.containsEntity(sender) && gameWorld.invoker(PlayerChatListener.EVENT).onSendChatMessage(message, sender) == ActionResult.FAIL) {
                 ci.cancel();
             }
             if ((((HasChatChannel) sender).getChatChannel()) != ChatChannel.TEAM) return;


### PR DESCRIPTION
Adds a new event named `PlayerChatListener`.

This event allows for games to listen and cancel for when a player sends a message in chat.

This is perfect for games that want to do something with the message that was sent in chat by the players or cancel a message sent.

For example, in Murder Mystery this allows the game to only send spectator messages to other spectators so they can't leak who the Murderer is.