### PR TITLE
Add a rule for sanitizing creative actions

### DIFF
--- a/src/main/java/xyz/nucleoid/plasmid/game/rule/GameRule.java
+++ b/src/main/java/xyz/nucleoid/plasmid/game/rule/GameRule.java
@@ -12,4 +12,5 @@ public final class GameRule {
     public static final GameRule THROW_ITEMS = new GameRule();
     public static final GameRule UNSTABLE_TNT = new GameRule();
     public static final GameRule TEAM_CHAT = new GameRule();
+    public static final GameRule SANITIZE_CREATIVE_ACTIONS = new GameRule();
 }

--- a/src/main/java/xyz/nucleoid/plasmid/mixin/game/rule/ServerPlayNetworkHandlerMixin.java
+++ b/src/main/java/xyz/nucleoid/plasmid/mixin/game/rule/ServerPlayNetworkHandlerMixin.java
@@ -1,0 +1,42 @@
+package xyz.nucleoid.plasmid.mixin.game.rule;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+import net.minecraft.item.ItemStack;
+import net.minecraft.network.packet.c2s.play.CreativeInventoryActionC2SPacket;
+import net.minecraft.server.network.ServerPlayNetworkHandler;
+import net.minecraft.server.network.ServerPlayerEntity;
+import xyz.nucleoid.plasmid.game.ManagedGameSpace;
+import xyz.nucleoid.plasmid.game.rule.GameRule;
+import xyz.nucleoid.plasmid.game.rule.RuleResult;
+import xyz.nucleoid.plasmid.util.ItemStackSanitizer;
+
+@Mixin(ServerPlayNetworkHandler.class)
+public class ServerPlayNetworkHandlerMixin {
+    @Shadow
+    public ServerPlayerEntity player;
+
+    @Redirect(
+            method = "onCreativeInventoryAction",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lnet/minecraft/network/packet/c2s/play/CreativeInventoryActionC2SPacket;getItemStack()Lnet/minecraft/item/ItemStack;"
+            )
+    )
+    private ItemStack modifyCreativeActionStack(CreativeInventoryActionC2SPacket packet) {
+        if (!this.player.getEntityWorld().isClient()) {
+            ManagedGameSpace gameSpace = ManagedGameSpace.forWorld(this.player.getEntityWorld());
+            if (gameSpace != null && gameSpace.containsPlayer(this.player)) {
+                RuleResult result = gameSpace.testRule(GameRule.SANITIZE_CREATIVE_ACTIONS);
+                if (result != RuleResult.DENY) {
+                    return ItemStackSanitizer.sanitize(packet.getItemStack());
+                }
+            }
+        }
+
+        return packet.getItemStack();
+    }
+}

--- a/src/main/java/xyz/nucleoid/plasmid/util/ItemStackSanitizer.java
+++ b/src/main/java/xyz/nucleoid/plasmid/util/ItemStackSanitizer.java
@@ -1,0 +1,50 @@
+package xyz.nucleoid.plasmid.util;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.CompoundTag;
+
+public final class ItemStackSanitizer {
+    private static final Set<String> WHITELISTED_KEYS = new HashSet<>();
+
+    public static boolean isWhitelistedKey(String key) {
+        return WHITELISTED_KEYS.contains(key);
+    }
+
+    public static void addWhitelistedKey(String key) {
+        WHITELISTED_KEYS.add(key);
+    }
+
+    /**
+     * Makes a sanitized copy of an item stack.
+     * 
+     * @param stack the stack to sanitize
+     */
+    public static ItemStack sanitize(ItemStack stack) {
+        ItemStack sanitizedStack = stack.copy();
+
+        CompoundTag tag = sanitizedStack.getTag();
+        if (tag != null) {
+            for (String key : tag.getKeys()) {
+                if (!isWhitelistedKey(key)) {
+                    tag.remove(key);
+                }
+            }
+        }
+
+        return sanitizedStack;
+    }
+    
+    static {
+        // General
+        addWhitelistedKey("Damage");
+        addWhitelistedKey("Unbreakable");
+
+        // Specific to certain items
+        addWhitelistedKey("BucketVariantTag"); // Tropical fish buckets
+        addWhitelistedKey("color"); // Leather armor
+        addWhitelistedKey("SkullOwner"); // Player heads
+    }
+}

--- a/src/main/resources/plasmid.mixins.json
+++ b/src/main/resources/plasmid.mixins.json
@@ -29,6 +29,7 @@
     "game.event.ScreenHandlerMixin",
     "game.rule.ServerPlayerEntityMixin",
     "game.rule.ServerPlayerInteractionManagerMixin",
+    "game.rule.ServerPlayNetworkHandlerMixin",
     "game.rule.TntBlockMixin",
     "storage.ServerWorldMixin"
   ],


### PR DESCRIPTION
This pull request adds the `SANITIZE_CREATIVE_ACTIONS` rule. Unless explicitly disabled, this removes all NBT tags from an  item stack picked in creative except the following:

- `Damage`
- `Unbreakable`
- `BucketVariantTag` used for tropical fish buckets
- `color` used for leather armor
- `SkullOwner` used for player heads

This rule breaks the use of valid potions and enchantment books, and clears all items from shulker boxes. Special cases will need to be made for these scenarios.