### PR TITLE
Formatting for translated text in the sidebar

### DIFF
--- a/src/main/java/xyz/nucleoid/plasmid/widget/SidebarWidget.java
+++ b/src/main/java/xyz/nucleoid/plasmid/widget/SidebarWidget.java
@@ -15,6 +15,7 @@ import net.minecraft.scoreboard.ScoreboardObjective;
 import net.minecraft.scoreboard.ServerScoreboard;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.text.LiteralText;
 import net.minecraft.text.Style;
 import net.minecraft.text.Text;
 import net.minecraft.text.TranslatableText;
@@ -26,7 +27,10 @@ import xyz.nucleoid.plasmid.game.player.MutablePlayerSet;
 import java.util.Arrays;
 import java.util.Objects;
 import java.util.function.Consumer;
+import java.util.function.Function;
 import java.util.function.UnaryOperator;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
 
 public final class SidebarWidget implements GameWidget {
     private static final int SIDEBAR_SLOT = 1;
@@ -129,11 +133,22 @@ public final class SidebarWidget implements GameWidget {
         }
 
         public Content writeFormattedTranslated(Formatting formatting, String key, Object... args) {
-            return this.writeRawLine(new TranslatableText(key, args).formatted(formatting));
+            // This is probably a really awful way of doing this, but simply calling .formatted() on a TranslatableText
+            // doesn't apply the formatting when using in the sidebar.
+            return this.writeRawLine(new LiteralText(formatting.toString()).append(new TranslatableText(key, args)));
         }
 
-        public Content writeStyledTranslated(UnaryOperator<Style> style, String key, Object... args) {
-            return this.writeRawLine(new TranslatableText(key, args).styled(style));
+        public Content writeFormattedTranslated(Formatting[] formatting, String key, Object... args) {
+            // Awful I know
+            return this.writeRawLine(new LiteralText(Arrays.stream(formatting).map(Formatting::toString).collect(Collectors.joining()))
+                    .append(new TranslatableText(key, args)));
+        }
+
+        public Content writeFormattedTranslated(Iterable<Formatting> formatting, String key, Object... args) {
+            // Again this is really awful.
+            return this.writeRawLine(new LiteralText(StreamSupport.stream(formatting.spliterator(), false)
+                    .map(Formatting::toString).collect(Collectors.joining()))
+                    .append(new TranslatableText(key, args)));
         }
 
         public Content writeTranslated(String key, Object... args) {

--- a/src/main/java/xyz/nucleoid/plasmid/widget/SidebarWidget.java
+++ b/src/main/java/xyz/nucleoid/plasmid/widget/SidebarWidget.java
@@ -15,7 +15,6 @@ import net.minecraft.scoreboard.ScoreboardObjective;
 import net.minecraft.scoreboard.ServerScoreboard;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.network.ServerPlayerEntity;
-import net.minecraft.text.LiteralText;
 import net.minecraft.text.Style;
 import net.minecraft.text.Text;
 import net.minecraft.text.TranslatableText;
@@ -25,12 +24,9 @@ import xyz.nucleoid.plasmid.game.GameSpace;
 import xyz.nucleoid.plasmid.game.player.MutablePlayerSet;
 
 import java.util.Arrays;
+import java.util.List;
 import java.util.Objects;
 import java.util.function.Consumer;
-import java.util.function.Function;
-import java.util.function.UnaryOperator;
-import java.util.stream.Collectors;
-import java.util.stream.StreamSupport;
 
 public final class SidebarWidget implements GameWidget {
     private static final int SIDEBAR_SLOT = 1;
@@ -133,22 +129,15 @@ public final class SidebarWidget implements GameWidget {
         }
 
         public Content writeFormattedTranslated(Formatting formatting, String key, Object... args) {
-            // This is probably a really awful way of doing this, but simply calling .formatted() on a TranslatableText
-            // doesn't apply the formatting when using in the sidebar.
-            return this.writeRawLine(new LiteralText(formatting.toString()).append(new TranslatableText(key, args)));
+            return this.writeRawLine(new TranslatableText(key, args).formatted(formatting));
         }
 
         public Content writeFormattedTranslated(Formatting[] formatting, String key, Object... args) {
-            // Awful I know
-            return this.writeRawLine(new LiteralText(Arrays.stream(formatting).map(Formatting::toString).collect(Collectors.joining()))
-                    .append(new TranslatableText(key, args)));
+            return this.writeRawLine(new TranslatableText(key, args).formatted(formatting));
         }
 
-        public Content writeFormattedTranslated(Iterable<Formatting> formatting, String key, Object... args) {
-            // Again this is really awful.
-            return this.writeRawLine(new LiteralText(StreamSupport.stream(formatting.spliterator(), false)
-                    .map(Formatting::toString).collect(Collectors.joining()))
-                    .append(new TranslatableText(key, args)));
+        public Content writeFormattedTranslated(List<Formatting> formatting, String key, Object... args) {
+            return this.writeRawLine(new TranslatableText(key, args).formatted(formatting.toArray(new Formatting[0])));
         }
 
         public Content writeTranslated(String key, Object... args) {
@@ -223,7 +212,34 @@ public final class SidebarWidget implements GameWidget {
             if (line instanceof String) {
                 text = (String) line;
             } else if (line instanceof Text) {
-                text = LocalizableText.asLocalizedFor((Text) line, (LocalizationTarget) player).getString();
+                Text txt = (Text) line;
+
+                StringBuilder message = new StringBuilder();
+                Style style = txt.getStyle();
+                if (style.getColor() != null && !style.getColor().getName().startsWith("#")) {
+                    message.append(Objects.requireNonNull(
+                            Formatting.byName(style.getColor().getName()),
+                            "formatting"
+                    ).toString());
+                }
+                if (style.isBold()) {
+                    message.append(Formatting.BOLD);
+                }
+                if (style.isItalic()) {
+                    message.append(Formatting.ITALIC);
+                }
+                if (style.isUnderlined()) {
+                    message.append(Formatting.UNDERLINE);
+                }
+                if (style.isStrikethrough()) {
+                    message.append(Formatting.STRIKETHROUGH);
+                }
+                if (style.isObfuscated()) {
+                    message.append(Formatting.OBFUSCATED);
+                }
+
+                message.append(LocalizableText.asLocalizedFor(txt, (LocalizationTarget) player).getString());
+                text = message.toString();
             } else {
                 text = line.toString();
             }

--- a/src/main/java/xyz/nucleoid/plasmid/widget/SidebarWidget.java
+++ b/src/main/java/xyz/nucleoid/plasmid/widget/SidebarWidget.java
@@ -15,6 +15,7 @@ import net.minecraft.scoreboard.ScoreboardObjective;
 import net.minecraft.scoreboard.ServerScoreboard;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.text.Style;
 import net.minecraft.text.Text;
 import net.minecraft.text.TranslatableText;
 import net.minecraft.util.Formatting;
@@ -25,6 +26,7 @@ import xyz.nucleoid.plasmid.game.player.MutablePlayerSet;
 import java.util.Arrays;
 import java.util.Objects;
 import java.util.function.Consumer;
+import java.util.function.UnaryOperator;
 
 public final class SidebarWidget implements GameWidget {
     private static final int SIDEBAR_SLOT = 1;
@@ -124,6 +126,14 @@ public final class SidebarWidget implements GameWidget {
 
         public Content writeLine(String line) {
             return this.writeRawLine(line);
+        }
+
+        public Content writeFormattedTranslated(Formatting formatting, String key, Object args) {
+            return this.writeRawLine(new TranslatableText(key, args).formatted(formatting));
+        }
+
+        public Content writeStyledTranslated(UnaryOperator<Style> style, String key, Object args) {
+            return this.writeRawLine(new TranslatableText(key, args).styled(style));
         }
 
         public Content writeTranslated(String key, Object... args) {

--- a/src/main/java/xyz/nucleoid/plasmid/widget/SidebarWidget.java
+++ b/src/main/java/xyz/nucleoid/plasmid/widget/SidebarWidget.java
@@ -128,11 +128,11 @@ public final class SidebarWidget implements GameWidget {
             return this.writeRawLine(line);
         }
 
-        public Content writeFormattedTranslated(Formatting formatting, String key, Object args) {
+        public Content writeFormattedTranslated(Formatting formatting, String key, Object... args) {
             return this.writeRawLine(new TranslatableText(key, args).formatted(formatting));
         }
 
-        public Content writeStyledTranslated(UnaryOperator<Style> style, String key, Object args) {
+        public Content writeStyledTranslated(UnaryOperator<Style> style, String key, Object... args) {
             return this.writeRawLine(new TranslatableText(key, args).styled(style));
         }
 


### PR DESCRIPTION
This PR adds two methods to `SidebarWidget.Content`, `writeFormattedTranslated` and `writeStyledTranslated`. These allow the application of `Formatting` or changes to the `Style` of the text in a similar way to the `.formatted()` and `.styled()` methods on Vanilla's `MutableText`