### PR TITLE
Use game IDs where possible for messages

### DIFF
--- a/src/main/java/xyz/nucleoid/plasmid/command/GameCommand.java
+++ b/src/main/java/xyz/nucleoid/plasmid/command/GameCommand.java
@@ -35,6 +35,7 @@ import xyz.nucleoid.plasmid.game.player.PlayerSet;
 import xyz.nucleoid.plasmid.util.Scheduler;
 
 import java.util.Comparator;
+import java.util.Optional;
 
 import static net.minecraft.server.command.CommandManager.argument;
 import static net.minecraft.server.command.CommandManager.literal;
@@ -140,7 +141,7 @@ public final class GameCommand {
                         if (player != null && ManagedGameSpace.forWorld(player.world) == null) {
                             channel.requestJoin(player);
                         }
-                        onOpenSuccess(source, channel, game, playerManager);
+                        onOpenSuccess(source, channel, gameId, game, playerManager);
                     } else {
                         onOpenError(playerManager, throwable);
                     }
@@ -154,8 +155,8 @@ public final class GameCommand {
         return Command.SINGLE_SUCCESS;
     }
 
-    private static void onOpenSuccess(ServerCommandSource source, GameChannel channel, ConfiguredGame<?> game, PlayerManager playerManager) {
-        Text openMessage = new TranslatableText("text.plasmid.game.open.opened", source.getDisplayName(), new LiteralText(game.getName()).formatted(Formatting.GRAY))
+    private static void onOpenSuccess(ServerCommandSource source, GameChannel channel, Identifier gameId, ConfiguredGame<?> game, PlayerManager playerManager) {
+        Text openMessage = new TranslatableText("text.plasmid.game.open.opened", source.getDisplayName(), new LiteralText(game.getDisplayName(gameId)).formatted(Formatting.GRAY))
                 .append(channel.createJoinLink());
 
         playerManager.broadcastChatMessage(openMessage, MessageType.SYSTEM, Util.NIL_UUID);

--- a/src/main/java/xyz/nucleoid/plasmid/command/argument/GameConfigArgument.java
+++ b/src/main/java/xyz/nucleoid/plasmid/command/argument/GameConfigArgument.java
@@ -30,7 +30,7 @@ public final class GameConfigArgument {
                     String remaining = builder.getRemaining().toLowerCase(Locale.ROOT);
 
                     CommandSource.forEachMatching(candidates, remaining, Function.identity(), id -> {
-                        builder.suggest(id.toString(), new LiteralText(GameConfigs.get(id).getName()));
+                        builder.suggest(id.toString(), new LiteralText(GameConfigs.get(id).getDisplayName(id)));
                     });
                     return builder.buildFuture();
                 });

--- a/src/main/java/xyz/nucleoid/plasmid/game/ManagedGameSpace.java
+++ b/src/main/java/xyz/nucleoid/plasmid/game/ManagedGameSpace.java
@@ -92,7 +92,8 @@ public final class ManagedGameSpace implements GameSpace {
             }
         });
 
-        this.errorReporter = ErrorReporter.open(gameConfig.getName() + " (" + gameConfig.getType().getIdentifier() + ")");
+        // TODO: Find a way to get the config ID here.
+        this.errorReporter = ErrorReporter.open(gameConfig.getOptionalName().orElse("<unnamed>") + " (" + gameConfig.getType().getIdentifier() + ")");
     }
 
     /**

--- a/src/main/java/xyz/nucleoid/plasmid/game/channel/on_demand/OnDemandGame.java
+++ b/src/main/java/xyz/nucleoid/plasmid/game/channel/on_demand/OnDemandGame.java
@@ -24,7 +24,7 @@ final class OnDemandGame {
     public Text getName() {
         ConfiguredGame<?> configuredGame = GameConfigs.get(this.gameId);
         if (configuredGame != null) {
-            return new LiteralText(configuredGame.getName()).formatted(Formatting.AQUA);
+            return new LiteralText(configuredGame.getDisplayName(this.gameId)).formatted(Formatting.AQUA);
         } else {
             return new LiteralText(this.gameId.toString()).formatted(Formatting.RED);
         }

--- a/src/main/java/xyz/nucleoid/plasmid/game/channel/oneshot/OneshotChannelBackend.java
+++ b/src/main/java/xyz/nucleoid/plasmid/game/channel/oneshot/OneshotChannelBackend.java
@@ -4,6 +4,7 @@ import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.text.LiteralText;
 import net.minecraft.text.Text;
 import net.minecraft.util.Formatting;
+import net.minecraft.util.Identifier;
 import xyz.nucleoid.plasmid.game.GameLifecycle;
 import xyz.nucleoid.plasmid.game.GameSpace;
 import xyz.nucleoid.plasmid.game.ManagedGameSpace;
@@ -15,10 +16,12 @@ import java.util.concurrent.CompletableFuture;
 
 public final class OneshotChannelBackend implements GameChannelBackend {
     private final ManagedGameSpace gameSpace;
+    private final Identifier gameId;
     private final GameChannelMembers members;
 
-    public OneshotChannelBackend(ManagedGameSpace gameSpace, GameChannelMembers members) {
+    public OneshotChannelBackend(ManagedGameSpace gameSpace, Identifier gameId, GameChannelMembers members) {
         this.gameSpace = gameSpace;
+        this.gameId = gameId;
         this.members = members;
 
         this.gameSpace.getLifecycle().addListeners(new LifecycleListeners());
@@ -26,7 +29,7 @@ public final class OneshotChannelBackend implements GameChannelBackend {
 
     @Override
     public Text getName() {
-        return new LiteralText(this.gameSpace.getGameConfig().getName()).formatted(Formatting.AQUA);
+        return new LiteralText(this.gameSpace.getGameConfig().getDisplayName(this.gameId)).formatted(Formatting.AQUA);
     }
 
     @Override

--- a/src/main/java/xyz/nucleoid/plasmid/game/channel/oneshot/OneshotChannelSystem.java
+++ b/src/main/java/xyz/nucleoid/plasmid/game/channel/oneshot/OneshotChannelSystem.java
@@ -44,7 +44,7 @@ public final class OneshotChannelSystem implements GameChannelSystem {
             }
         });
 
-        return new GameChannel(this.server, id, members -> new OneshotChannelBackend(gameSpace, members));
+        return new GameChannel(this.server, id, members -> new OneshotChannelBackend(gameSpace, gameId, members));
     }
 
     private Identifier createChannelIdFor(Identifier gameId) {


### PR DESCRIPTION
Replaces `ConfiguredGame.getName()` with two new methods `getOptionalName()` and `getDisplayName(gameId)` that fix the broken behavior shown below:
![image](https://user-images.githubusercontent.com/23531706/103948088-17d4c700-5131-11eb-8b86-b72aeadc1448.png)
(use of the `GameType` id rather than the id of the game config itself)