### PR TITLE
Add the locate subcommand to the game command

### DIFF
--- a/src/main/java/xyz/nucleoid/plasmid/game/config/GameConfigs.java
+++ b/src/main/java/xyz/nucleoid/plasmid/game/config/GameConfigs.java
@@ -80,6 +80,11 @@ public final class GameConfigs {
         return CONFIGURED_GAMES.get(identifier);
     }
 
+    @Nullable
+    public static Identifier getIdentifier(ConfiguredGame<?> game) {
+        return CONFIGURED_GAMES.getIdentifier(game);
+    }
+
     public static Set<Identifier> getKeys() {
         return CONFIGURED_GAMES.keySet();
     }

--- a/src/main/java/xyz/nucleoid/plasmid/game/config/GameConfigs.java
+++ b/src/main/java/xyz/nucleoid/plasmid/game/config/GameConfigs.java
@@ -80,11 +80,6 @@ public final class GameConfigs {
         return CONFIGURED_GAMES.get(identifier);
     }
 
-    @Nullable
-    public static Identifier getIdentifier(ConfiguredGame<?> game) {
-        return CONFIGURED_GAMES.getIdentifier(game);
-    }
-
     public static Set<Identifier> getKeys() {
         return CONFIGURED_GAMES.keySet();
     }

--- a/src/main/resources/data/plasmid/lang/en_us.json
+++ b/src/main/resources/data/plasmid/lang/en_us.json
@@ -17,6 +17,7 @@
   "text.plasmid.game.open.opened": "%1$s has opened %2$s! ",
   "text.plasmid.game.open.join": "Click here to join",
   "text.plasmid.game.propose": "%1$s has proposed %2$s! ",
+  "text.plasmid.game.locate.located": "%s is currently in the %s game. ",
   "text.plasmid.game.waiting_lobby.bar.waiting": "Waiting for players...",
   "text.plasmid.game.waiting_lobby.bar.countdown": "Starting in %s seconds!",
   "text.plasmid.game.waiting_lobby.bar.cancel": "Game start cancelled! ",


### PR DESCRIPTION
This pull request adds the `locate` subcommand. It can be used to find which channel a player is in, and sends a link to join the channel.

Fixes #79