### PR TITLE
Use names rather than identifiers in the game list

### DIFF
--- a/src/main/java/xyz/nucleoid/plasmid/command/GameCommand.java
+++ b/src/main/java/xyz/nucleoid/plasmid/command/GameCommand.java
@@ -378,7 +378,7 @@ public final class GameCommand {
                     .withClickEvent(linkClick)
                     .withHoverEvent(linkHover);
 
-            MutableText link = new LiteralText(id.toString()).setStyle(linkStyle);
+            MutableText link = GameConfigs.get(id).getNameText().shallowCopy().setStyle(linkStyle);
             source.sendFeedback(new LiteralText(" - ").append(link), false);
         }
 


### PR DESCRIPTION
This pull request changes the output of the `/game list` command to show the names of games rather than their identifiers.

![/game list command output](https://user-images.githubusercontent.com/24855774/108876296-17529b80-75cc-11eb-8e4f-57ba136660c8.png)
