### PR TITLE
Add subcommands to allow retrieving the bounds of maps and map regions

### DIFF
--- a/src/main/java/xyz/nucleoid/plasmid/command/MapManageCommand.java
+++ b/src/main/java/xyz/nucleoid/plasmid/command/MapManageCommand.java
@@ -414,7 +414,7 @@ public final class MapManageCommand {
         }, Util.getIoWorkerExecutor());
     }
 
-    private static Text getClickablePosText(BlockPos pos) {
+    protected static Text getClickablePosText(BlockPos pos) {
         String linkCommand = "/tp @s " + pos.getX() + " " + pos.getY() + " " + pos.getZ();
         Style linkStyle = Style.EMPTY
                 .withClickEvent(new ClickEvent(ClickEvent.Action.SUGGEST_COMMAND, linkCommand))

--- a/src/main/java/xyz/nucleoid/plasmid/command/MapManageCommand.java
+++ b/src/main/java/xyz/nucleoid/plasmid/command/MapManageCommand.java
@@ -17,8 +17,13 @@ import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.command.ServerCommandSource;
 import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.server.world.ServerWorld;
+import net.minecraft.text.ClickEvent;
+import net.minecraft.text.HoverEvent;
 import net.minecraft.text.LiteralText;
 import net.minecraft.text.MutableText;
+import net.minecraft.text.Style;
+import net.minecraft.text.Text;
+import net.minecraft.text.Texts;
 import net.minecraft.text.TranslatableText;
 import net.minecraft.util.Formatting;
 import net.minecraft.util.Identifier;
@@ -92,10 +97,12 @@ public final class MapManageCommand {
                 )))
                 .then(literal("bounds")
                     .then(MapWorkspaceArgument.argument("workspace")
-                    .then(argument("min", BlockPosArgumentType.blockPos())
-                    .then(argument("max", BlockPosArgumentType.blockPos())
-                    .executes(MapManageCommand::setWorkspaceBounds)
-                ))))
+                        .executes(MapManageCommand::getWorkspaceBounds)
+                        .then(argument("min", BlockPosArgumentType.blockPos())
+                            .then(argument("max", BlockPosArgumentType.blockPos())
+                            .executes(MapManageCommand::setWorkspaceBounds)
+                        ))
+                ))
                 .then(literal("join")
                     .then(MapWorkspaceArgument.argument("workspace")
                     .executes(MapManageCommand::joinWorkspace)
@@ -206,6 +213,17 @@ public final class MapManageCommand {
         workspace.setOrigin(origin);
 
         source.sendFeedback(new LiteralText("Updated origin for workspace"), false);
+
+        return Command.SINGLE_SUCCESS;
+    }
+
+    private static int getWorkspaceBounds(CommandContext<ServerCommandSource> context) throws CommandSyntaxException {
+        ServerCommandSource source = context.getSource();
+
+        MapWorkspace workspace = MapWorkspaceArgument.get(context, "workspace");
+        BlockBounds bounds = workspace.getBounds();
+
+        source.sendFeedback(new TranslatableText("The bounds for the workspace are %s to %s", getClickablePosText(bounds.getMin()), getClickablePosText(bounds.getMax())), false);
 
         return Command.SINGLE_SUCCESS;
     }
@@ -394,5 +412,15 @@ public final class MapManageCommand {
                 }
             }
         }, Util.getIoWorkerExecutor());
+    }
+
+    private static Text getClickablePosText(BlockPos pos) {
+        String linkCommand = "/tp @s " + pos.getX() + " " + pos.getY() + " " + pos.getZ();
+        Style linkStyle = Style.EMPTY
+                .withClickEvent(new ClickEvent(ClickEvent.Action.SUGGEST_COMMAND, linkCommand))
+                .withHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, new TranslatableText("chat.coordinates.tooltip")))
+                .withFormatting(Formatting.GREEN);
+
+        return Texts.bracketed(new TranslatableText("chat.coordinates", pos.getX(), pos.getY(), pos.getZ())).setStyle(linkStyle);
     }
 }

--- a/src/main/java/xyz/nucleoid/plasmid/command/MapMetadataCommand.java
+++ b/src/main/java/xyz/nucleoid/plasmid/command/MapMetadataCommand.java
@@ -95,6 +95,10 @@ public final class MapMetadataCommand {
                             )
                         )))
                     )
+                    .then(literal("bounds")
+                        .then(argument("marker", StringArgumentType.word()).suggests(regionSuggestions())
+                        .executes(MapMetadataCommand::getRegionBounds))
+                    )
                     .then(literal("data")
                         .then(argument("marker", StringArgumentType.word()).suggests(localRegionSuggestions())
                             .then(literal("get").executes(executeInRegions("", MapMetadataCommand::executeRegionDataGet)))
@@ -224,6 +228,28 @@ public final class MapMetadataCommand {
         }
 
         source.sendFeedback(withMapPrefix(map, new LiteralText("Renamed " + regions.size() + " regions.")), false);
+
+        return Command.SINGLE_SUCCESS;
+    }
+    
+    private static int getRegionBounds(CommandContext<ServerCommandSource> context) throws CommandSyntaxException {
+        ServerCommandSource source = context.getSource();
+        MapWorkspace map = getWorkspaceForSource(source);
+
+        String marker = StringArgumentType.getString(context, "marker");
+
+        List<WorkspaceRegion> regions = map.getRegions().stream()
+                .filter(region -> region.marker.equals(marker))
+                .collect(Collectors.toList());
+
+        source.sendFeedback(new TranslatableText("Found %s regions:", regions.size()).formatted(Formatting.BOLD), false);
+
+        for (WorkspaceRegion region : regions) {
+            Text minText = MapManageCommand.getClickablePosText(region.bounds.getMin());
+            Text maxText = MapManageCommand.getClickablePosText(region.bounds.getMax());
+
+            source.sendFeedback(new TranslatableText(" - %s to %s", minText, maxText), false);
+        }
 
         return Command.SINGLE_SUCCESS;
     }


### PR DESCRIPTION
This pull request adds the `/map bounds <workspace>` and `/map region bounds <marker>` commands, which show the bounds of the specified workspace and any region with the specified marker respectively.