### PR TITLE
Add additional game close reasons

### DIFF
--- a/src/main/java/xyz/nucleoid/plasmid/Plasmid.java
+++ b/src/main/java/xyz/nucleoid/plasmid/Plasmid.java
@@ -205,7 +205,7 @@ public final class Plasmid implements ModInitializer {
         ServerWorldEvents.UNLOAD.register((server, world) -> {
             ManagedGameSpace gameSpace = ManagedGameSpace.forWorld(world);
             if (gameSpace != null) {
-                gameSpace.close(GameCloseReason.CANCELED);
+                gameSpace.close(GameCloseReason.GARBAGE_COLLECTED);
             }
         });
     }

--- a/src/main/java/xyz/nucleoid/plasmid/game/GameCloseReason.java
+++ b/src/main/java/xyz/nucleoid/plasmid/game/GameCloseReason.java
@@ -1,8 +1,26 @@
 package xyz.nucleoid.plasmid.game;
 
+/**
+ * Represents a reason for a game to close.
+ * 
+ * <p>To close a game, see {@link GameSpace#close}.
+ * <p>To listen for game closure, see {@link xyz.nucleoid.plasmid.event.GameEvents#CLOSING}.
+ */
 public enum GameCloseReason {
+    /**
+     * Used when a game ends normally.
+     */
     FINISHED,
+    /**
+     * Used when the server closes or a player manually runs a command to close the game.
+     */
     CANCELED,
+    /**
+     * Used when the game space is unloaded or the game's last player leaves, making the game no longer useful.
+     */
     GARBAGE_COLLECTED,
+    /**
+     * Used when an exception is thrown that requires the game to close.
+     */
     ERRORED,
 }

--- a/src/main/java/xyz/nucleoid/plasmid/game/GameCloseReason.java
+++ b/src/main/java/xyz/nucleoid/plasmid/game/GameCloseReason.java
@@ -3,4 +3,5 @@ package xyz.nucleoid.plasmid.game;
 public enum GameCloseReason {
     FINISHED,
     CANCELED,
+    ERRORED,
 }

--- a/src/main/java/xyz/nucleoid/plasmid/game/GameCloseReason.java
+++ b/src/main/java/xyz/nucleoid/plasmid/game/GameCloseReason.java
@@ -3,5 +3,6 @@ package xyz.nucleoid.plasmid.game;
 public enum GameCloseReason {
     FINISHED,
     CANCELED,
+    GARBAGE_COLLECTED,
     ERRORED,
 }

--- a/src/main/java/xyz/nucleoid/plasmid/game/ManagedGameSpace.java
+++ b/src/main/java/xyz/nucleoid/plasmid/game/ManagedGameSpace.java
@@ -266,7 +266,7 @@ public final class ManagedGameSpace implements GameSpace {
         this.lifecycle.removePlayer(this, player);
 
         if (this.getPlayerCount() <= 0) {
-            this.close(GameCloseReason.CANCELED);
+            this.close(GameCloseReason.GARBAGE_COLLECTED);
         }
     }
 

--- a/src/main/java/xyz/nucleoid/plasmid/game/ManagedGameSpace.java
+++ b/src/main/java/xyz/nucleoid/plasmid/game/ManagedGameSpace.java
@@ -381,7 +381,7 @@ public final class ManagedGameSpace implements GameSpace {
 
     public void closeWithError(String message) {
         this.getPlayers().sendMessage(new LiteralText(message).formatted(Formatting.RED));
-        this.close(GameCloseReason.CANCELED);
+        this.close(GameCloseReason.ERRORED);
     }
 
     @Override


### PR DESCRIPTION
This pull request adds two new game close reasons for errored and garbage collected games. It also documents the `GameCloseReason` enum in order to explain where to use the enum and in which scenarios each reason is used.