### PR TITLE
Add game packets

### DIFF
--- a/doc/network.md
+++ b/doc/network.md
@@ -106,6 +106,21 @@ Direction: `C<-S`
 | player_count   | int        | The new player count of the game space after the player joined. |
 | player_uuid    | UUID       | The UUID of the player that joined the game space.              |
 
+#### `plasmid:game/player_removed`
+
+Packet sent when a player is remove from a game space.
+
+Direction: `C<-S`
+
+| Fields         | Type       | Description                                                         |
+|:--------------:|:----------:|:--------------------------------------------------------------------|
+| game_type_id   | Identifier | The identifier of the game type.                                    |
+| game_type_name | Text       | The name of the game type.                                          |
+| game_id        | Identifier | The identifier of the game.                                         |
+| game_name      | Text       | The name of the game.                                               |
+| player_count   | int        | The new player count of the game space after the player is removed. |
+| player_uuid    | UUID       | The UUID of the player that was removed from the game space.        |
+
 ### Workspace-related Packets
 
 The server controls most of the requests sent by a client for workspace-related packets as it requires some permissions.

--- a/doc/network.md
+++ b/doc/network.md
@@ -93,7 +93,8 @@ Size: 0 if non-present, else size of `X`.
 
 #### `plasmid:game/player_add`
 
-Packet sent when a player is joined to a game space.
+Packet sent to all players of a game space when a player is joined to a game space.
+The player that was joined to the game space also receives this packet.
 
 Direction: `C<-S`
 
@@ -108,7 +109,8 @@ Direction: `C<-S`
 
 #### `plasmid:game/player_removed`
 
-Packet sent when a player is remove from a game space.
+Packet sent to all players of a game space when a player is removed from a game space.
+The player that was removed from the game space also receives this packet.
 
 Direction: `C<-S`
 
@@ -123,7 +125,7 @@ Direction: `C<-S`
 
 #### `plasmid:game/game_close`
 
-Packet sent when a game space closes.
+Packet sent to all players in a game space when it closes.
 
 Direction: `C<-S`
 

--- a/doc/network.md
+++ b/doc/network.md
@@ -89,6 +89,23 @@ Size: 0 if non-present, else size of `X`.
 
 ## Packets
 
+### Game-related Packets
+
+#### `plasmid:game/player_add`
+
+Packet sent when a player is joined to a game space.
+
+Direction: `C<-S`
+
+| Fields         | Type       | Description                                                     |
+|:--------------:|:----------:|:----------------------------------------------------------------|
+| game_type_id   | Identifier | The identifier of the game type.                                |
+| game_type_name | Text       | The name of the game type.                                      |
+| game_id        | Identifier | The identifier of the game.                                     |
+| game_name      | Text       | The name of the game.                                           |
+| player_count   | int        | The new player count of the game space after the player joined. |
+| player_uuid    | UUID       | The UUID of the player that joined the game space.              |
+
 ### Workspace-related Packets
 
 The server controls most of the requests sent by a client for workspace-related packets as it requires some permissions.

--- a/doc/network.md
+++ b/doc/network.md
@@ -121,6 +121,20 @@ Direction: `C<-S`
 | player_count   | int        | The new player count of the game space after the player is removed. |
 | player_uuid    | UUID       | The UUID of the player that was removed from the game space.        |
 
+#### `plasmid:game/game_close`
+
+Packet sent when a game space closes.
+
+Direction: `C<-S`
+
+| Fields         | Type            | Description                        |
+|:--------------:|:---------------:|:-----------------------------------|
+| game_type_id   | Identifier      | The identifier of the game type.   |
+| game_type_name | Text            | The name of the game type.         |
+| game_id        | Identifier      | The identifier of the game.        |
+| game_name      | Text            | The name of the game.              |
+| reason         | GameCloseReason | The reason for the game's closure. |
+
 ### Workspace-related Packets
 
 The server controls most of the requests sent by a client for workspace-related packets as it requires some permissions.

--- a/src/main/java/xyz/nucleoid/plasmid/event/GamePackets.java
+++ b/src/main/java/xyz/nucleoid/plasmid/event/GamePackets.java
@@ -1,0 +1,58 @@
+package xyz.nucleoid.plasmid.event;
+
+import java.util.function.Consumer;
+
+import io.netty.buffer.Unpooled;
+import net.minecraft.network.PacketByteBuf;
+import net.minecraft.network.packet.s2c.play.CustomPayloadS2CPacket;
+import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.util.Identifier;
+import xyz.nucleoid.plasmid.Plasmid;
+import xyz.nucleoid.plasmid.game.ConfiguredGame;
+import xyz.nucleoid.plasmid.game.GameSpace;
+import xyz.nucleoid.plasmid.game.GameType;
+
+/**
+ * A helper class for creating {@linkplain net.minecraft.network.packet.c2s.play.CustomPayloadC2SPacket custom payload packets} to send to clients.
+ */
+public final class GamePackets {
+    private GamePackets() { }
+
+    public static CustomPayloadS2CPacket playerAdd(GameSpace gameSpace, ServerPlayerEntity player) {
+        return createPacket("player_add", buf -> writeGameAndPlayerInfo(buf, gameSpace, player));
+    }
+
+    private static void writeGameAndPlayerInfo(PacketByteBuf buf, GameSpace gameSpace, ServerPlayerEntity player) {
+        writeGameInfo(buf, gameSpace);
+        writePlayerInfo(buf, gameSpace, player);
+    }
+
+    private static void writeGameInfo(PacketByteBuf buf, GameSpace gameSpace) {
+        ConfiguredGame<?> game = gameSpace.getGameConfig();
+        GameType<?> gameType = game.getType();
+
+        // Game type ID and name
+        buf.writeIdentifier(gameType.getIdentifier());
+        buf.writeText(gameType.getName());
+
+        // Game ID and name
+        buf.writeIdentifier(game.getSource());
+        buf.writeText(game.getNameText());
+    }
+
+    private static void writePlayerInfo(PacketByteBuf buf, GameSpace gameSpace, ServerPlayerEntity player) {
+        buf.writeInt(gameSpace.getPlayerCount());
+        buf.writeUuid(player.getUuid());
+    }
+
+    private static CustomPayloadS2CPacket createPacket(String type, Consumer<PacketByteBuf> writer) {
+        PacketByteBuf buf = new PacketByteBuf(Unpooled.buffer());
+        writer.accept(buf);
+
+        return new CustomPayloadS2CPacket(createChannel(type), buf);
+    }
+
+    private static Identifier createChannel(String type) {
+        return new Identifier(Plasmid.ID, "game/" + type);
+    }
+}

--- a/src/main/java/xyz/nucleoid/plasmid/event/GamePackets.java
+++ b/src/main/java/xyz/nucleoid/plasmid/event/GamePackets.java
@@ -9,6 +9,7 @@ import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.util.Identifier;
 import xyz.nucleoid.plasmid.Plasmid;
 import xyz.nucleoid.plasmid.game.ConfiguredGame;
+import xyz.nucleoid.plasmid.game.GameCloseReason;
 import xyz.nucleoid.plasmid.game.GameSpace;
 import xyz.nucleoid.plasmid.game.GameType;
 
@@ -24,6 +25,13 @@ public final class GamePackets {
 
     public static CustomPayloadS2CPacket playerRemove(GameSpace gameSpace, ServerPlayerEntity player) {
         return createPacket("player_remove", buf -> writeGameAndPlayerInfo(buf, gameSpace, player));
+    }
+
+    public static CustomPayloadS2CPacket gameClose(GameSpace gameSpace, GameCloseReason reason) {
+        return createPacket("game_close", buf -> {
+            writeGameInfo(buf, gameSpace);
+            buf.writeString(reason == GameCloseReason.FINISHED ? "finished" : "canceled");
+        });
     }
 
     private static void writeGameAndPlayerInfo(PacketByteBuf buf, GameSpace gameSpace, ServerPlayerEntity player) {

--- a/src/main/java/xyz/nucleoid/plasmid/event/GamePackets.java
+++ b/src/main/java/xyz/nucleoid/plasmid/event/GamePackets.java
@@ -22,6 +22,10 @@ public final class GamePackets {
         return createPacket("player_add", buf -> writeGameAndPlayerInfo(buf, gameSpace, player));
     }
 
+    public static CustomPayloadS2CPacket playerRemove(GameSpace gameSpace, ServerPlayerEntity player) {
+        return createPacket("player_remove", buf -> writeGameAndPlayerInfo(buf, gameSpace, player));
+    }
+
     private static void writeGameAndPlayerInfo(PacketByteBuf buf, GameSpace gameSpace, ServerPlayerEntity player) {
         writeGameInfo(buf, gameSpace);
         writePlayerInfo(buf, gameSpace, player);

--- a/src/main/java/xyz/nucleoid/plasmid/game/ManagedGameSpace.java
+++ b/src/main/java/xyz/nucleoid/plasmid/game/ManagedGameSpace.java
@@ -24,6 +24,7 @@ import xyz.nucleoid.leukocyte.authority.Authority;
 import xyz.nucleoid.leukocyte.shape.ProtectionShape;
 import xyz.nucleoid.plasmid.error.ErrorReporter;
 import xyz.nucleoid.plasmid.event.GameEvents;
+import xyz.nucleoid.plasmid.event.GamePackets;
 import xyz.nucleoid.plasmid.game.event.*;
 import xyz.nucleoid.plasmid.game.player.JoinResult;
 import xyz.nucleoid.plasmid.game.player.MutablePlayerSet;
@@ -238,6 +239,7 @@ public final class ManagedGameSpace implements GameSpace {
             }
 
             this.lifecycle.addPlayer(this, player);
+            GamePackets.playerAdd(this, player);
 
             return true;
         }

--- a/src/main/java/xyz/nucleoid/plasmid/game/ManagedGameSpace.java
+++ b/src/main/java/xyz/nucleoid/plasmid/game/ManagedGameSpace.java
@@ -266,6 +266,7 @@ public final class ManagedGameSpace implements GameSpace {
 
         this.players.remove(player);
         this.lifecycle.removePlayer(this, player);
+        GamePackets.playerRemove(this, player);
 
         if (this.getPlayerCount() <= 0) {
             this.close(GameCloseReason.CANCELED);

--- a/src/main/java/xyz/nucleoid/plasmid/game/ManagedGameSpace.java
+++ b/src/main/java/xyz/nucleoid/plasmid/game/ManagedGameSpace.java
@@ -364,6 +364,7 @@ public final class ManagedGameSpace implements GameSpace {
                 this.resources.close();
 
                 this.lifecycle.onClosed(this, players, reason);
+                GamePackets.gameClose(this, reason);
 
                 Leukocyte leukocyte = Leukocyte.get(this.getServer());
                 leukocyte.removeAuthority(this.ruleAuthority);


### PR DESCRIPTION
This pull request adds a simple set of custom payload packets that are sent to clients when a player is added or removed from a game space, or a game space is closed.