### PR TITLE
MODIFY_INVENTORY and MODIFY_ARMOR gamerule

### DIFF
--- a/src/main/java/xyz/nucleoid/plasmid/game/rule/GameRule.java
+++ b/src/main/java/xyz/nucleoid/plasmid/game/rule/GameRule.java
@@ -20,7 +20,8 @@ public final class GameRule {
     public static final GameRule DISMOUNT_VEHICLE = new GameRule();
     public static final GameRule PLAYER_PROJECTILE_KNOCKBACK = new GameRule();
     public static final GameRule TRIDENTS_LOYAL_IN_VOID = new GameRule();
-    public static final GameRule MODIFY_INVENTORIES = new GameRule();
+    public static final GameRule MODIFY_INVENTORY = new GameRule();
+    public static final GameRule MODIFY_ARMOUR = new GameRule();
 
     private final ProtectionRule rule;
 

--- a/src/main/java/xyz/nucleoid/plasmid/game/rule/GameRule.java
+++ b/src/main/java/xyz/nucleoid/plasmid/game/rule/GameRule.java
@@ -20,6 +20,7 @@ public final class GameRule {
     public static final GameRule DISMOUNT_VEHICLE = new GameRule();
     public static final GameRule PLAYER_PROJECTILE_KNOCKBACK = new GameRule();
     public static final GameRule TRIDENTS_LOYAL_IN_VOID = new GameRule();
+    public static final GameRule MODIFY_INVENTORIES = new GameRule();
 
     private final ProtectionRule rule;
 

--- a/src/main/java/xyz/nucleoid/plasmid/game/rule/GameRule.java
+++ b/src/main/java/xyz/nucleoid/plasmid/game/rule/GameRule.java
@@ -21,7 +21,7 @@ public final class GameRule {
     public static final GameRule PLAYER_PROJECTILE_KNOCKBACK = new GameRule();
     public static final GameRule TRIDENTS_LOYAL_IN_VOID = new GameRule();
     public static final GameRule MODIFY_INVENTORY = new GameRule();
-    public static final GameRule MODIFY_ARMOUR = new GameRule();
+    public static final GameRule MODIFY_ARMOR = new GameRule();
 
     private final ProtectionRule rule;
 

--- a/src/main/java/xyz/nucleoid/plasmid/mixin/game/rule/ServerPlayNetworkHandlerMixin.java
+++ b/src/main/java/xyz/nucleoid/plasmid/mixin/game/rule/ServerPlayNetworkHandlerMixin.java
@@ -1,11 +1,18 @@
 package xyz.nucleoid.plasmid.mixin.game.rule;
 
 import net.minecraft.entity.Entity;
+import net.minecraft.item.ItemStack;
 import net.minecraft.network.Packet;
+import net.minecraft.network.packet.c2s.play.ClickSlotC2SPacket;
 import net.minecraft.network.packet.c2s.play.PlayerMoveC2SPacket;
+import net.minecraft.network.packet.s2c.play.ConfirmScreenActionS2CPacket;
 import net.minecraft.network.packet.s2c.play.EntityPassengersSetS2CPacket;
+import net.minecraft.network.packet.s2c.play.PlaySoundS2CPacket;
+import net.minecraft.network.packet.s2c.play.ScreenHandlerSlotUpdateS2CPacket;
 import net.minecraft.server.network.ServerPlayNetworkHandler;
 import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.sound.SoundCategory;
+import net.minecraft.sound.SoundEvents;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
@@ -45,6 +52,36 @@ public abstract class ServerPlayNetworkHandlerMixin {
             // the player is probably desynchronized: update them with the vehicle passengers
             Entity vehicle = this.player.getVehicle();
             this.sendPacket(new EntityPassengersSetS2CPacket(vehicle));
+        }
+    }
+
+    @Inject(
+            method = "onClickSlot",
+            cancellable = true,
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lnet/minecraft/network/NetworkThreadUtils;forceMainThread(Lnet/minecraft/network/Packet;Lnet/minecraft/network/listener/PacketListener;Lnet/minecraft/server/world/ServerWorld;)V",
+                    shift = At.Shift.AFTER
+            )
+    )
+    private void onClickSlot(ClickSlotC2SPacket packet, CallbackInfo ci) {
+        ManagedGameSpace gameSpace = ManagedGameSpace.forWorld(this.player.world);
+
+        if (gameSpace != null) {
+            if (gameSpace.testRule(GameRule.MODIFY_INVENTORIES) == RuleResult.DENY) {
+                ci.cancel();
+                // this.player.playSound didn't appear to work, but a packet did.
+                this.sendPacket(new PlaySoundS2CPacket(
+                        SoundEvents.ENTITY_VILLAGER_NO, SoundCategory.MASTER,
+                        this.player.getX(), this.player.getY(), this.player.getZ(),
+                        1.0f, 1.0f
+                ));
+                ItemStack stack = this.player.inventory.getStack(packet.getSlot());
+                this.sendPacket(new ScreenHandlerSlotUpdateS2CPacket(packet.getSyncId(), packet.getSlot(), stack));
+                this.player.refreshScreenHandler(this.player.currentScreenHandler);
+                this.sendPacket(new ScreenHandlerSlotUpdateS2CPacket(-1, -1, this.player.inventory.getCursorStack()));
+                this.sendPacket(new ConfirmScreenActionS2CPacket(packet.getSyncId(), packet.getActionId(), false));
+            }
         }
     }
 }

--- a/src/main/java/xyz/nucleoid/plasmid/mixin/game/rule/ServerPlayNetworkHandlerMixin.java
+++ b/src/main/java/xyz/nucleoid/plasmid/mixin/game/rule/ServerPlayNetworkHandlerMixin.java
@@ -70,9 +70,11 @@ public abstract class ServerPlayNetworkHandlerMixin {
         if (gameSpace != null) {
             if (packet.getSlot() < 0 || packet.getSlot() >= this.player.inventory.size()) return;
             // See https://wiki.vg/File:Inventory-slots.png for the slot numbering
-            GameRule rule = (packet.getSlot() >= 5 && packet.getSlot() <= 8) ? GameRule.MODIFY_ARMOR : GameRule.MODIFY_INVENTORY;
-            if (gameSpace.testRule(rule) == RuleResult.DENY) {
-
+            boolean isArmor = (packet.getSlot() >= 5 && packet.getSlot() <= 8);
+            boolean denyModifyInventory = gameSpace.testRule(GameRule.MODIFY_INVENTORY) == RuleResult.DENY;
+            RuleResult modifyArmor = gameSpace.testRule(GameRule.MODIFY_ARMOR);
+            if ((denyModifyInventory && (!isArmor || modifyArmor != RuleResult.ALLOW))
+                    || (isArmor && modifyArmor == RuleResult.DENY)) {
                 ItemStack stack = this.player.inventory.getStack(packet.getSlot());
 
                 ci.cancel();

--- a/src/main/java/xyz/nucleoid/plasmid/mixin/game/rule/ServerPlayNetworkHandlerMixin.java
+++ b/src/main/java/xyz/nucleoid/plasmid/mixin/game/rule/ServerPlayNetworkHandlerMixin.java
@@ -70,7 +70,7 @@ public abstract class ServerPlayNetworkHandlerMixin {
         if (gameSpace != null) {
             if (packet.getSlot() < 0 || packet.getSlot() >= this.player.inventory.size()) return;
             // See https://wiki.vg/File:Inventory-slots.png for the slot numbering
-            GameRule rule = (packet.getSlot() >= 5 && packet.getSlot() <= 8) ? GameRule.MODIFY_ARMOUR : GameRule.MODIFY_INVENTORY;
+            GameRule rule = (packet.getSlot() >= 5 && packet.getSlot() <= 8) ? GameRule.MODIFY_ARMOR : GameRule.MODIFY_INVENTORY;
             if (gameSpace.testRule(rule) == RuleResult.DENY) {
 
                 ItemStack stack = this.player.inventory.getStack(packet.getSlot());

--- a/src/main/java/xyz/nucleoid/plasmid/mixin/game/rule/ServerPlayNetworkHandlerMixin.java
+++ b/src/main/java/xyz/nucleoid/plasmid/mixin/game/rule/ServerPlayNetworkHandlerMixin.java
@@ -32,8 +32,6 @@ public abstract class ServerPlayNetworkHandlerMixin {
     @Shadow
     public abstract void sendPacket(Packet<?> packet);
 
-    @Shadow @Final private static Logger LOGGER;
-
     @Inject(
             method = "onPlayerMove",
             at = @At(

--- a/src/main/java/xyz/nucleoid/plasmid/mixin/game/rule/ServerPlayNetworkHandlerMixin.java
+++ b/src/main/java/xyz/nucleoid/plasmid/mixin/game/rule/ServerPlayNetworkHandlerMixin.java
@@ -13,8 +13,6 @@ import net.minecraft.server.network.ServerPlayNetworkHandler;
 import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.sound.SoundCategory;
 import net.minecraft.sound.SoundEvents;
-import org.apache.logging.log4j.Logger;
-import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
@@ -70,8 +68,10 @@ public abstract class ServerPlayNetworkHandlerMixin {
         ManagedGameSpace gameSpace = ManagedGameSpace.forWorld(this.player.world);
 
         if (gameSpace != null) {
-            if (gameSpace.testRule(GameRule.MODIFY_INVENTORIES) == RuleResult.DENY) {
-                if (packet.getSlot() < 0 || packet.getSlot() >= this.player.inventory.size()) return;
+            if (packet.getSlot() < 0 || packet.getSlot() >= this.player.inventory.size()) return;
+            // See https://wiki.vg/File:Inventory-slots.png for the slot numbering
+            GameRule rule = (packet.getSlot() >= 5 && packet.getSlot() <= 8) ? GameRule.MODIFY_ARMOUR : GameRule.MODIFY_INVENTORY;
+            if (gameSpace.testRule(rule) == RuleResult.DENY) {
 
                 ItemStack stack = this.player.inventory.getStack(packet.getSlot());
 

--- a/src/main/java/xyz/nucleoid/plasmid/test/TestGame.java
+++ b/src/main/java/xyz/nucleoid/plasmid/test/TestGame.java
@@ -42,6 +42,7 @@ public final class TestGame {
             game.setRule(GameRule.PVP, RuleResult.ALLOW);
             game.setRule(GameRule.THROW_ITEMS, RuleResult.DENY);
             game.setRule(GameRule.MODIFY_INVENTORY, RuleResult.DENY);
+            game.setRule(GameRule.MODIFY_ARMOR, RuleResult.ALLOW);
 
             game.on(PlayerDeathListener.EVENT, (player, source) -> {
                 player.teleport(0.0, 65.0, 0.0);

--- a/src/main/java/xyz/nucleoid/plasmid/test/TestGame.java
+++ b/src/main/java/xyz/nucleoid/plasmid/test/TestGame.java
@@ -41,7 +41,7 @@ public final class TestGame {
             game.setRule(GameRule.HUNGER, RuleResult.DENY);
             game.setRule(GameRule.PVP, RuleResult.ALLOW);
             game.setRule(GameRule.THROW_ITEMS, RuleResult.DENY);
-            game.setRule(GameRule.MODIFY_INVENTORIES, RuleResult.DENY);
+            game.setRule(GameRule.MODIFY_INVENTORY, RuleResult.DENY);
 
             game.on(PlayerDeathListener.EVENT, (player, source) -> {
                 player.teleport(0.0, 65.0, 0.0);

--- a/src/main/java/xyz/nucleoid/plasmid/test/TestGame.java
+++ b/src/main/java/xyz/nucleoid/plasmid/test/TestGame.java
@@ -41,6 +41,7 @@ public final class TestGame {
             game.setRule(GameRule.HUNGER, RuleResult.DENY);
             game.setRule(GameRule.PVP, RuleResult.ALLOW);
             game.setRule(GameRule.THROW_ITEMS, RuleResult.DENY);
+            game.setRule(GameRule.MODIFY_INVENTORIES, RuleResult.DENY);
 
             game.on(PlayerDeathListener.EVENT, (player, source) -> {
                 player.teleport(0.0, 65.0, 0.0);


### PR DESCRIPTION
Adds a new gamerule for minigames that specifies whether players can move items around in their inventories. The villager 'no' sound is also played if users can't move items, however there are some cases where it doesn't (mostly when shift-clicking items)