### PR TITLE
Add class to search for blocks around

### DIFF
--- a/src/main/java/xyz/nucleoid/plasmid/util/BucketFind.java
+++ b/src/main/java/xyz/nucleoid/plasmid/util/BucketFind.java
@@ -1,5 +1,7 @@
 package xyz.nucleoid.plasmid.util;
 
+import it.unimi.dsi.fastutil.longs.LongArraySet;
+import it.unimi.dsi.fastutil.longs.LongSet;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
 import net.minecraft.server.world.ServerWorld;
@@ -14,7 +16,7 @@ import java.util.Set;
 import java.util.function.Predicate;
 
 /**
- * Methods for finding connected blocks.
+ * Methods for finding connected blocks as a {@link LongSet}. Use {@link BlockPos#fromLong} to retrieve these positions.
  *
  * @see <a href="https://en.wikipedia.org/wiki/Pixel_connectivity#3-dimensional">3-dimensional pixel connectivity</a>
  */
@@ -23,130 +25,130 @@ public final class BucketFind {
     }
 
     /**
-     * Finds any 6-connected blocks and puts them in a set.
+     * Finds any 6-connected blocks and puts them in a {@link LongSet}.
      *
      * @param origin    the position of the first block
      * @param depth     the amount of maximum blocks to find
      * @param predicate the predicate for the blocks that can be accepted in the set
      */
-    public static Set<BlockPos> findSix(ServerWorld world, BlockPos origin, int depth, Predicate<BlockState> predicate) {
-        Set<BlockPos> set = new HashSet<>();
+    public static LongSet findSix(ServerWorld world, BlockPos origin, int depth, Predicate<BlockState> predicate) {
+        LongSet set = new LongArraySet();
         Deque<BlockPos> ends = new ArrayDeque<>();
         ends.push(origin);
-        BlockPos.Mutable local;
+        BlockPos.Mutable local = origin.mutableCopy();
         while(depth > 0) {
             if(ends.isEmpty()) {
                 return set;
             }
             BlockPos pos = ends.pollLast();
             for(Direction direction : Direction.values()) {
-                local = pos.offset(direction).mutableCopy();
-                if(predicate.test(world.getBlockState(local)) && !set.contains(local)) {
-                    ends.push(local);
+                local.set(pos).offset(direction);
+                if(predicate.test(world.getBlockState(local)) && !set.contains(local.asLong()) && !ends.contains(local)) {
+                    ends.push(local.toImmutable());
                 }
             }
-            set.add(pos);
+            set.add(pos.asLong());
             depth--;
         }
         return set;
     }
 
     /**
-     * Finds any 6-connected blocks and puts them in a set.
+     * Finds any 6-connected blocks and puts them in a {@link LongSet}.
      *
      * @param origin the position of the first block
      * @param depth  the amount of maximum blocks to find
      * @param tag    the tag for the blocks that can be accepted in the set
      */
-    public static Set<BlockPos> findSix(ServerWorld world, BlockPos origin, int depth, Tag<Block> tag) {
+    public static LongSet findSix(ServerWorld world, BlockPos origin, int depth, Tag<Block> tag) {
         return findSix(world, origin, depth, state -> state.isIn(tag));
     }
 
     /**
-     * Finds any 6-connected blocks and puts them in a set.
+     * Finds any 6-connected blocks and puts them in a {@link LongSet}.
      *
      * @param origin the position of the first block
      * @param depth  the amount of maximum blocks to find
      * @param block  the block type that can be accepted in the set
      */
-    public static Set<BlockPos> findSix(ServerWorld world, BlockPos origin, int depth, Block block) {
+    public static LongSet findSix(ServerWorld world, BlockPos origin, int depth, Block block) {
         return findSix(world, origin, depth, state -> state.isOf(block));
     }
 
     /**
-     * Finds any 18-connected blocks and puts them in a set.
+     * Finds any 18-connected blocks and puts them in a {@link LongSet}..
      *
      * @param origin    the position of the first block
      * @param depth     the amount of maximum blocks to find
      * @param predicate the predicate for the blocks that can be accepted in the set
      */
-    public static Set<BlockPos> findEighteen(ServerWorld world, BlockPos origin, int depth, Predicate<BlockState> predicate) {
-        Set<BlockPos> set = new HashSet<>();
+    public static LongSet findEighteen(ServerWorld world, BlockPos origin, int depth, Predicate<BlockState> predicate) {
+        LongSet set = new LongArraySet();
         Deque<BlockPos> ends = new ArrayDeque<>();
         ends.push(origin);
-        BlockPos.Mutable local;
+        BlockPos.Mutable local = origin.mutableCopy();
         while(depth > 0) {
             if(ends.isEmpty()) {
                 return set;
             }
             BlockPos pos = ends.pollLast();
             for(Direction direction : Direction.values()) {
-                local = pos.offset(direction).mutableCopy();
-                if(predicate.test(world.getBlockState(local)) && !set.contains(local) && !ends.contains(local)) {
-                    ends.push(local);
+                local.set(pos).offset(direction);
+                if(predicate.test(world.getBlockState(local)) && !set.contains(local.asLong()) && !ends.contains(local)) {
+                    ends.push(local.toImmutable());
                 }
             }
             for(int x = -1; x <= 1; x += 2) {
                 for(int y = -1; y <= 1; y += 2) {
                     for(int z = -1; z <= 1; z += 2) {
-                        local = pos.add(x, y, z).mutableCopy();
+                        local.set(pos).add(x, y, z);
                         BlockState state = world.getBlockState(local);
-                        if(predicate.test(state) && !set.contains(local) && !ends.contains(local)) {
-                            ends.push(local);
+                        if(predicate.test(state) && !set.contains(local.asLong()) && !ends.contains(local)) {
+                            ends.push(local.toImmutable());
                         }
                     }
                 }
             }
-            set.add(pos);
+            set.add(pos.asLong());
             depth--;
         }
         return set;
     }
 
     /**
-     * Finds any 18-connected blocks and puts them in a set.
+     * Finds any 18-connected blocks and puts them in a {@link LongSet}.
      *
      * @param origin the position of the first block
      * @param depth  the amount of maximum blocks to find
      * @param tag    the tag for the blocks that can be accepted in the set
      */
-    public static Set<BlockPos> findEighteen(ServerWorld world, BlockPos origin, int depth, Tag<Block> tag) {
+    public static LongSet findEighteen(ServerWorld world, BlockPos origin, int depth, Tag<Block> tag) {
         return findEighteen(world, origin, depth, state -> state.isIn(tag));
     }
 
     /**
-     * Finds any 18-connected blocks and puts them in a set.
+     * Finds any 18-connected blocks and puts them in a {@link LongSet}.
      *
      * @param origin the position of the first block
      * @param depth  the amount of maximum blocks to find
      * @param block  the block type that can be accepted in the set
      */
-    public static Set<BlockPos> findEighteen(ServerWorld world, BlockPos origin, int depth, Block block) {
+    public static LongSet findEighteen(ServerWorld world, BlockPos origin, int depth, Block block) {
         return findEighteen(world, origin, depth, state -> state.isOf(block));
     }
 
     /**
-     * Finds any 26-connected blocks and puts them in a set.
+     * Finds any 26-connected blocks and puts them in a {@link LongSet}.
      *
      * @param origin    the position of the first block
      * @param depth     the amount of maximum blocks to find
      * @param predicate the predicate for the blocks that can be accepted in the set
      */
-    public static Set<BlockPos> findTwentySix(ServerWorld world, BlockPos origin, int depth, Predicate<BlockState> predicate) {
-        Set<BlockPos> set = new HashSet<>();
+    public static LongSet findTwentySix(ServerWorld world, BlockPos origin, int depth, Predicate<BlockState> predicate) {
+        LongSet set = new LongArraySet();
         Deque<BlockPos> ends = new ArrayDeque<>();
         ends.push(origin);
-        BlockPos.Mutable local;
+        BlockPos.Mutable local = origin.mutableCopy();
         while(depth > 0) {
             if(ends.isEmpty()) {
                 return set;
@@ -156,38 +158,38 @@ public final class BucketFind {
                 for(int y = -1; y <= 1; y++) {
                     for(int z = -1; z <= 1; z++) {
                         if(x == 0 && y == 0 && z == 0) continue;
-                        local = pos.add(x, y, z).mutableCopy();
-                        if(predicate.test(world.getBlockState(local)) && !set.contains(local) && !ends.contains(local)) {
-                            ends.push(local);
+                        local.set(pos).add(x, y, z);
+                        if(predicate.test(world.getBlockState(local)) && !set.contains(local.asLong()) && !ends.contains(local)) {
+                            ends.push(local.toImmutable());
                         }
                     }
                 }
             }
-            set.add(pos);
+            set.add(pos.asLong());
             depth--;
         }
         return set;
     }
 
     /**
-     * Finds any 26-connected blocks and puts them in a set.
+     * Finds any 26-connected blocks and puts them in a {@link LongSet}.
      *
      * @param origin the position of the first block
      * @param depth  the amount of maximum blocks to find
      * @param tag    the tag for the blocks that can be accepted in the set
      */
-    public static Set<BlockPos> findTwentySix(ServerWorld world, BlockPos origin, int depth, Tag<Block> tag) {
+    public static LongSet findTwentySix(ServerWorld world, BlockPos origin, int depth, Tag<Block> tag) {
         return findTwentySix(world, origin, depth, state -> state.isIn(tag));
     }
 
     /**
-     * Finds any 26-connected blocks and puts them in a set.
+     * Finds any 26-connected blocks and puts them in a {@link LongSet}.
      *
      * @param origin the position of the first block
      * @param depth  the amount of maximum blocks to find
      * @param block  the block type that can be accepted in the set
      */
-    public static Set<BlockPos> findTwentySix(ServerWorld world, BlockPos origin, int depth, Block block) {
+    public static LongSet findTwentySix(ServerWorld world, BlockPos origin, int depth, Block block) {
         return findTwentySix(world, origin, depth, state -> state.isOf(block));
     }
 }

--- a/src/main/java/xyz/nucleoid/plasmid/util/BucketFind.java
+++ b/src/main/java/xyz/nucleoid/plasmid/util/BucketFind.java
@@ -107,14 +107,19 @@ public final class BucketFind {
                     ends.push(local.toImmutable());
                 }
             }
-            for(int x = -1; x <= 1; x += 2) {
-                for(int y = -1; y <= 1; y += 2) {
-                    for(int z = -1; z <= 1; z += 2) {
-                        local.set(pos.add(x, y, z));
-                        BlockState state = world.getBlockState(local);
-                        if(predicate.test(state) && !set.contains(local.asLong()) && !ends.contains(local)) {
-                            ends.push(local.toImmutable());
-                        }
+            for(int i = -1; i <= 1; i += 2) {
+                for(int j = -1; j <= 1; j += 2) {
+                    local.set(pos.add(i, j, 0));
+                    if(predicate.test(world.getBlockState(local)) && !set.contains(local.asLong()) && !ends.contains(local)) {
+                        ends.push(local.toImmutable());
+                    }
+                    local.set(pos.add(0, i, j));
+                    if(predicate.test(world.getBlockState(local)) && !set.contains(local.asLong()) && !ends.contains(local)) {
+                        ends.push(local.toImmutable());
+                    }
+                    local.set(pos.add(j, 0, i));
+                    if(predicate.test(world.getBlockState(local)) && !set.contains(local.asLong()) && !ends.contains(local)) {
+                        ends.push(local.toImmutable());
                     }
                 }
             }

--- a/src/main/java/xyz/nucleoid/plasmid/util/BucketFind.java
+++ b/src/main/java/xyz/nucleoid/plasmid/util/BucketFind.java
@@ -13,54 +13,36 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.function.Predicate;
 
+/**
+ * Methods for finding connected blocks.
+ *
+ * @see <a href="https://en.wikipedia.org/wiki/Pixel_connectivity#3-dimensional">3-dimensional pixel connectivity</a>
+ */
 public final class BucketFind {
     private BucketFind() {
     }
 
     /**
-     * Finds any directly connected blocks and puts them in a set.
+     * Finds any 6-connected blocks and puts them in a set.
      *
-     * @param origin the position of the first block
-     * @param depth the amount of maximum blocks to find
-     * @param block the block type that can be accepted in the set
-     */
-    public static Set<BlockPos> find(ServerWorld world, BlockPos origin, int depth, Block block) {
-        return find(world, origin, depth, state -> state.isOf(block));
-    }
-
-    /**
-     * Finds any directly connected blocks and puts them in a set.
-     *
-     * @param origin the position of the first block
-     * @param depth the amount of maximum blocks to find
-     * @param tag the tag for the blocks that can be accepted in the set
-     */
-    public static Set<BlockPos> find(ServerWorld world, BlockPos origin, int depth, Tag<Block> tag) {
-        return find(world, origin, depth, state -> state.isIn(tag));
-    }
-
-    /**
-     * Finds any directly connected blocks and puts them in a set.
-     *
-     * @param origin the position of the first block
-     * @param depth the amount of maximum blocks to find
+     * @param origin    the position of the first block
+     * @param depth     the amount of maximum blocks to find
      * @param predicate the predicate for the blocks that can be accepted in the set
      */
-    public static Set<BlockPos> find(ServerWorld world, BlockPos origin, int depth, Predicate<BlockState> predicate) {
+    public static Set<BlockPos> findSix(ServerWorld world, BlockPos origin, int depth, Predicate<BlockState> predicate) {
         Set<BlockPos> set = new HashSet<>();
         Deque<BlockPos> ends = new ArrayDeque<>();
         ends.push(origin);
         BlockPos.Mutable local;
-        while (depth > 0) {
-            if (ends.isEmpty()) {
+        while(depth > 0) {
+            if(ends.isEmpty()) {
                 return set;
             }
             BlockPos pos = ends.pollLast();
-            for (Direction direction : Direction.values()) {
+            for(Direction direction : Direction.values()) {
                 local = pos.offset(direction).mutableCopy();
-                BlockState state = world.getBlockState(local);
-                if (predicate.test(state)) {
-                    if (!set.contains(local)) {
+                if(predicate.test(world.getBlockState(local))) {
+                    if(!set.contains(local)) {
                         ends.push(local);
                     }
                 }
@@ -69,5 +51,151 @@ public final class BucketFind {
             depth--;
         }
         return set;
+    }
+
+    /**
+     * Finds any 6-connected blocks and puts them in a set.
+     *
+     * @param origin the position of the first block
+     * @param depth  the amount of maximum blocks to find
+     * @param tag    the tag for the blocks that can be accepted in the set
+     */
+    public static Set<BlockPos> findSix(ServerWorld world, BlockPos origin, int depth, Tag<Block> tag) {
+        return findSix(world, origin, depth, state -> state.isIn(tag));
+    }
+
+    /**
+     * Finds any 6-connected blocks and puts them in a set.
+     *
+     * @param origin the position of the first block
+     * @param depth  the amount of maximum blocks to find
+     * @param block  the block type that can be accepted in the set
+     */
+    public static Set<BlockPos> findSix(ServerWorld world, BlockPos origin, int depth, Block block) {
+        return findSix(world, origin, depth, state -> state.isOf(block));
+    }
+
+    /**
+     * Finds any 18-connected blocks and puts them in a set.
+     *
+     * @param origin    the position of the first block
+     * @param depth     the amount of maximum blocks to find
+     * @param predicate the predicate for the blocks that can be accepted in the set
+     */
+    public static Set<BlockPos> findEighteen(ServerWorld world, BlockPos origin, int depth, Predicate<BlockState> predicate) {
+        Set<BlockPos> set = new HashSet<>();
+        Deque<BlockPos> ends = new ArrayDeque<>();
+        ends.push(origin);
+        BlockPos.Mutable local;
+        while(depth > 0) {
+            if(ends.isEmpty()) {
+                return set;
+            }
+            BlockPos pos = ends.pollLast();
+            for(Direction direction : Direction.values()) {
+                local = pos.offset(direction).mutableCopy();
+                if(predicate.test(world.getBlockState(local))) {
+                    if(!set.contains(local)) {
+                        ends.push(local);
+                    }
+                }
+            }
+            for(int x = -1; x <= 1; x += 2) {
+                for(int y = -1; y <= 1; y += 2) {
+                    for(int z = -1; z <= 1; z += 2) {
+                        local = pos.add(x, y, z).mutableCopy();
+                        BlockState state = world.getBlockState(local);
+                        if(predicate.test(state)) {
+                            if(!set.contains(local)) {
+                                ends.push(local);
+                            }
+                        }
+                    }
+                }
+            }
+            set.add(pos);
+            depth--;
+        }
+        return set;
+    }
+
+    /**
+     * Finds any 18-connected blocks and puts them in a set.
+     *
+     * @param origin the position of the first block
+     * @param depth  the amount of maximum blocks to find
+     * @param tag    the tag for the blocks that can be accepted in the set
+     */
+    public static Set<BlockPos> findEighteen(ServerWorld world, BlockPos origin, int depth, Tag<Block> tag) {
+        return findEighteen(world, origin, depth, state -> state.isIn(tag));
+    }
+
+    /**
+     * Finds any 18-connected blocks and puts them in a set.
+     *
+     * @param origin the position of the first block
+     * @param depth  the amount of maximum blocks to find
+     * @param block  the block type that can be accepted in the set
+     */
+    public static Set<BlockPos> findEighteen(ServerWorld world, BlockPos origin, int depth, Block block) {
+        return findEighteen(world, origin, depth, state -> state.isOf(block));
+    }
+
+    /**
+     * Finds any 26-connected blocks and puts them in a set.
+     *
+     * @param origin    the position of the first block
+     * @param depth     the amount of maximum blocks to find
+     * @param predicate the predicate for the blocks that can be accepted in the set
+     */
+    public static Set<BlockPos> findTwentySix(ServerWorld world, BlockPos origin, int depth, Predicate<BlockState> predicate) {
+        Set<BlockPos> set = new HashSet<>();
+        Deque<BlockPos> ends = new ArrayDeque<>();
+        ends.push(origin);
+        BlockPos.Mutable local;
+        while(depth > 0) {
+            if(ends.isEmpty()) {
+                return set;
+            }
+            BlockPos pos = ends.pollLast();
+            for(int x = -1; x <= 1; x++) {
+                for(int y = -1; y <= 1; y++) {
+                    for(int z = -1; z <= 1; z++) {
+                        if(x == 0 && y == 0 && z == 0) continue;
+                        local = pos.add(x, y, z).mutableCopy();
+                        if(predicate.test(world.getBlockState(local))) {
+                            if(!set.contains(local)) {
+                                ends.push(local);
+                            }
+                        }
+                    }
+                }
+            }
+            set.add(pos);
+            depth--;
+        }
+        return set;
+    }
+
+    /**
+     * Finds any 26-connected blocks and puts them in a set.
+     *
+     * @param origin the position of the first block
+     * @param depth  the amount of maximum blocks to find
+     * @param tag    the tag for the blocks that can be accepted in the set
+     */
+    public static Set<BlockPos> findTwentySix(ServerWorld world, BlockPos origin, int depth, Tag<Block> tag) {
+        return findTwentySix(world, origin, depth, state -> state.isIn(tag));
+    }
+
+    /**
+     * Finds any 26-connected blocks and puts them in a set.
+     *
+     * @param origin the position of the first block
+     * @param depth  the amount of maximum blocks to find
+     * @param block  the block type that can be accepted in the set
+     */
+    public static Set<BlockPos> findTwentySix(ServerWorld world, BlockPos origin, int depth, Block block) {
+        return findTwentySix(world, origin, depth, state -> state.isOf(block));
     }
 }

--- a/src/main/java/xyz/nucleoid/plasmid/util/BucketFind.java
+++ b/src/main/java/xyz/nucleoid/plasmid/util/BucketFind.java
@@ -5,14 +5,12 @@ import it.unimi.dsi.fastutil.longs.LongSet;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
 import net.minecraft.server.world.ServerWorld;
+import net.minecraft.structure.rule.RuleTest;
 import net.minecraft.tag.Tag;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Direction;
 
-import java.util.ArrayDeque;
-import java.util.Deque;
-import java.util.HashSet;
-import java.util.Set;
+import java.util.*;
 import java.util.function.Predicate;
 
 /**
@@ -51,6 +49,17 @@ public final class BucketFind {
             depth--;
         }
         return set;
+    }
+
+    /**
+     * Finds any 6-connected blocks and puts them in a {@link LongSet}.
+     *
+     * @param origin   the position of the first block
+     * @param depth    the amount of maximum blocks to find
+     * @param ruleTest the rule test for the blocks that can be accepted in the set
+     */
+    public static LongSet findSix(ServerWorld world, BlockPos origin, int depth, RuleTest ruleTest, Random random) {
+        return findSix(world, origin, depth, state -> ruleTest.test(state, random));
     }
 
     /**
@@ -118,6 +127,17 @@ public final class BucketFind {
     /**
      * Finds any 18-connected blocks and puts them in a {@link LongSet}.
      *
+     * @param origin   the position of the first block
+     * @param depth    the amount of maximum blocks to find
+     * @param ruleTest the rule test for the blocks that can be accepted in the set
+     */
+    public static LongSet findEighteen(ServerWorld world, BlockPos origin, int depth, RuleTest ruleTest, Random random) {
+        return findEighteen(world, origin, depth, state -> ruleTest.test(state, random));
+    }
+
+    /**
+     * Finds any 18-connected blocks and puts them in a {@link LongSet}.
+     *
      * @param origin the position of the first block
      * @param depth  the amount of maximum blocks to find
      * @param tag    the tag for the blocks that can be accepted in the set
@@ -169,6 +189,17 @@ public final class BucketFind {
             depth--;
         }
         return set;
+    }
+
+    /**
+     * Finds any 26-connected blocks and puts them in a {@link LongSet}.
+     *
+     * @param origin   the position of the first block
+     * @param depth    the amount of maximum blocks to find
+     * @param ruleTest the rule test for the blocks that can be accepted in the set
+     */
+    public static LongSet findTwentySix(ServerWorld world, BlockPos origin, int depth, RuleTest ruleTest, Random random) {
+        return findTwentySix(world, origin, depth, state -> ruleTest.test(state, random));
     }
 
     /**

--- a/src/main/java/xyz/nucleoid/plasmid/util/BucketFind.java
+++ b/src/main/java/xyz/nucleoid/plasmid/util/BucketFind.java
@@ -41,10 +41,8 @@ public final class BucketFind {
             BlockPos pos = ends.pollLast();
             for(Direction direction : Direction.values()) {
                 local = pos.offset(direction).mutableCopy();
-                if(predicate.test(world.getBlockState(local))) {
-                    if(!set.contains(local)) {
-                        ends.push(local);
-                    }
+                if(predicate.test(world.getBlockState(local)) && !set.contains(local)) {
+                    ends.push(local);
                 }
             }
             set.add(pos);
@@ -94,10 +92,8 @@ public final class BucketFind {
             BlockPos pos = ends.pollLast();
             for(Direction direction : Direction.values()) {
                 local = pos.offset(direction).mutableCopy();
-                if(predicate.test(world.getBlockState(local))) {
-                    if(!set.contains(local)) {
-                        ends.push(local);
-                    }
+                if(predicate.test(world.getBlockState(local)) && !set.contains(local) && !ends.contains(local)) {
+                    ends.push(local);
                 }
             }
             for(int x = -1; x <= 1; x += 2) {
@@ -105,10 +101,8 @@ public final class BucketFind {
                     for(int z = -1; z <= 1; z += 2) {
                         local = pos.add(x, y, z).mutableCopy();
                         BlockState state = world.getBlockState(local);
-                        if(predicate.test(state)) {
-                            if(!set.contains(local)) {
-                                ends.push(local);
-                            }
+                        if(predicate.test(state) && !set.contains(local) && !ends.contains(local)) {
+                            ends.push(local);
                         }
                     }
                 }
@@ -163,10 +157,8 @@ public final class BucketFind {
                     for(int z = -1; z <= 1; z++) {
                         if(x == 0 && y == 0 && z == 0) continue;
                         local = pos.add(x, y, z).mutableCopy();
-                        if(predicate.test(world.getBlockState(local))) {
-                            if(!set.contains(local)) {
-                                ends.push(local);
-                            }
+                        if(predicate.test(world.getBlockState(local)) && !set.contains(local) && !ends.contains(local)) {
+                            ends.push(local);
                         }
                     }
                 }

--- a/src/main/java/xyz/nucleoid/plasmid/util/BucketFind.java
+++ b/src/main/java/xyz/nucleoid/plasmid/util/BucketFind.java
@@ -1,0 +1,43 @@
+package xyz.nucleoid.plasmid.util;
+
+import net.minecraft.block.Block;
+import net.minecraft.block.BlockState;
+import net.minecraft.server.world.ServerWorld;
+import net.minecraft.tag.Tag;
+import net.minecraft.util.math.BlockPos;
+
+import java.util.HashSet;
+import java.util.Set;
+
+public class BucketFind {
+    /**
+     * Finds any near blocks and puts them in a set.
+     *
+     * @param pos      The position of the first block
+     * @param blockTag The tag of the blocks that can be accepted in the set
+     */
+    public static Set<BlockPos> find(ServerWorld world, BlockPos pos, Tag<Block> blockTag) {
+        Set<BlockPos> positions = new HashSet<>();
+        positions.add(pos);
+        searchAround(world, pos, positions, blockTag);
+        return positions;
+    }
+
+    private static void searchAround(ServerWorld world, BlockPos pos, Set<BlockPos> positions, Tag<Block> blockTag) {
+        for(int x = -1; x <= 1; x++) {
+            for(int z = -1; z <= 1; z++) {
+                for(int y = -1; y <= 1; y++) {
+                    BlockPos local = pos.add(x, y, z);
+                    BlockState state = world.getBlockState(local);
+
+                    if(!positions.contains(local)) {
+                        if(state.isIn(blockTag)) {
+                            positions.add(local);
+                            searchAround(world, local, positions, blockTag);
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/xyz/nucleoid/plasmid/util/BucketFind.java
+++ b/src/main/java/xyz/nucleoid/plasmid/util/BucketFind.java
@@ -7,6 +7,8 @@ import net.minecraft.tag.Tag;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Direction;
 
+import java.util.ArrayDeque;
+import java.util.Deque;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.function.Predicate;
@@ -46,25 +48,24 @@ public final class BucketFind {
      */
     public static Set<BlockPos> find(ServerWorld world, BlockPos origin, int depth, Predicate<BlockState> predicate) {
         Set<BlockPos> set = new HashSet<>();
-        Set<BlockPos> ends = new HashSet<>();
-        ends.add(origin);
+        Deque<BlockPos> ends = new ArrayDeque<>();
+        ends.push(origin);
         BlockPos.Mutable local;
         while (depth > 0) {
             if (ends.isEmpty()) {
                 return set;
             }
-            BlockPos pos = ends.stream().findAny().get();
+            BlockPos pos = ends.pollLast();
             for (Direction direction : Direction.values()) {
                 local = pos.offset(direction).mutableCopy();
                 BlockState state = world.getBlockState(local);
                 if (predicate.test(state)) {
                     if (!set.contains(local)) {
-                        ends.add(local);
+                        ends.push(local);
                     }
                 }
             }
             set.add(pos);
-            ends.remove(pos);
             depth--;
         }
         return set;

--- a/src/main/java/xyz/nucleoid/plasmid/util/BucketFind.java
+++ b/src/main/java/xyz/nucleoid/plasmid/util/BucketFind.java
@@ -1,7 +1,9 @@
 package xyz.nucleoid.plasmid.util;
 
+import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
 import net.minecraft.server.world.ServerWorld;
+import net.minecraft.tag.Tag;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Direction;
 
@@ -10,34 +12,59 @@ import java.util.Set;
 import java.util.function.Predicate;
 
 public final class BucketFind {
+    private BucketFind() {
+    }
+
     /**
      * Finds any directly connected blocks and puts them in a set.
      *
-     * @param origin The position of the first block
-     * @param predicate The predicate for the blocks that can be accepted in the set
-     * @param limit The amount of maximum blocks to find
+     * @param origin the position of the first block
+     * @param depth the amount of maximum blocks to find
+     * @param block the block type that can be accepted in the set
      */
-    public static Set<BlockPos> find(ServerWorld world, BlockPos origin, Predicate<BlockState> predicate, int limit) {
+    public static Set<BlockPos> find(ServerWorld world, BlockPos origin, int depth, Block block) {
+        return find(world, origin, depth, state -> state.isOf(block));
+    }
+
+    /**
+     * Finds any directly connected blocks and puts them in a set.
+     *
+     * @param origin the position of the first block
+     * @param depth the amount of maximum blocks to find
+     * @param tag the tag for the blocks that can be accepted in the set
+     */
+    public static Set<BlockPos> find(ServerWorld world, BlockPos origin, int depth, Tag<Block> tag) {
+        return find(world, origin, depth, state -> state.isIn(tag));
+    }
+
+    /**
+     * Finds any directly connected blocks and puts them in a set.
+     *
+     * @param origin the position of the first block
+     * @param depth the amount of maximum blocks to find
+     * @param predicate the predicate for the blocks that can be accepted in the set
+     */
+    public static Set<BlockPos> find(ServerWorld world, BlockPos origin, int depth, Predicate<BlockState> predicate) {
         Set<BlockPos> set = new HashSet<>();
         Set<BlockPos> ends = new HashSet<>();
         ends.add(origin);
-        while(limit > 0) {
-            if(ends.isEmpty()) {
+        while (depth > 0) {
+            if (ends.isEmpty()) {
                 return set;
             }
             BlockPos pos = ends.stream().findAny().get();
-            for(Direction direction : Direction.values()) {
+            for (Direction direction : Direction.values()) {
                 BlockPos.Mutable local = pos.offset(direction).mutableCopy();
                 BlockState state = world.getBlockState(local);
-                if(predicate.test(state)) {
-                    if(!set.contains(local)) {
+                if (predicate.test(state)) {
+                    if (!set.contains(local)) {
                         ends.add(local);
                     }
                 }
             }
             set.add(pos);
             ends.remove(pos);
-            limit--;
+            depth--;
         }
         return set;
     }

--- a/src/main/java/xyz/nucleoid/plasmid/util/BucketFind.java
+++ b/src/main/java/xyz/nucleoid/plasmid/util/BucketFind.java
@@ -40,7 +40,7 @@ public final class BucketFind {
             }
             BlockPos pos = ends.pollLast();
             for(Direction direction : Direction.values()) {
-                local.set(pos).offset(direction);
+                local.set(pos.offset(direction));
                 if(predicate.test(world.getBlockState(local)) && !set.contains(local.asLong()) && !ends.contains(local)) {
                     ends.push(local.toImmutable());
                 }
@@ -102,7 +102,7 @@ public final class BucketFind {
             }
             BlockPos pos = ends.pollLast();
             for(Direction direction : Direction.values()) {
-                local.set(pos).offset(direction);
+                local.set(pos.offset(direction));
                 if(predicate.test(world.getBlockState(local)) && !set.contains(local.asLong()) && !ends.contains(local)) {
                     ends.push(local.toImmutable());
                 }
@@ -110,7 +110,7 @@ public final class BucketFind {
             for(int x = -1; x <= 1; x += 2) {
                 for(int y = -1; y <= 1; y += 2) {
                     for(int z = -1; z <= 1; z += 2) {
-                        local.set(pos).add(x, y, z);
+                        local.set(pos.add(x, y, z));
                         BlockState state = world.getBlockState(local);
                         if(predicate.test(state) && !set.contains(local.asLong()) && !ends.contains(local)) {
                             ends.push(local.toImmutable());
@@ -178,7 +178,7 @@ public final class BucketFind {
                 for(int y = -1; y <= 1; y++) {
                     for(int z = -1; z <= 1; z++) {
                         if(x == 0 && y == 0 && z == 0) continue;
-                        local.set(pos).add(x, y, z);
+                        local.set(pos.add(x, y, z));
                         if(predicate.test(world.getBlockState(local)) && !set.contains(local.asLong()) && !ends.contains(local)) {
                             ends.push(local.toImmutable());
                         }

--- a/src/main/java/xyz/nucleoid/plasmid/util/BucketFind.java
+++ b/src/main/java/xyz/nucleoid/plasmid/util/BucketFind.java
@@ -48,13 +48,14 @@ public final class BucketFind {
         Set<BlockPos> set = new HashSet<>();
         Set<BlockPos> ends = new HashSet<>();
         ends.add(origin);
+        BlockPos.Mutable local;
         while (depth > 0) {
             if (ends.isEmpty()) {
                 return set;
             }
             BlockPos pos = ends.stream().findAny().get();
             for (Direction direction : Direction.values()) {
-                BlockPos.Mutable local = pos.offset(direction).mutableCopy();
+                local = pos.offset(direction).mutableCopy();
                 BlockState state = world.getBlockState(local);
                 if (predicate.test(state)) {
                     if (!set.contains(local)) {

--- a/src/main/java/xyz/nucleoid/plasmid/util/BucketScanner.java
+++ b/src/main/java/xyz/nucleoid/plasmid/util/BucketScanner.java
@@ -18,8 +18,41 @@ import java.util.function.Predicate;
  *
  * @see <a href="https://en.wikipedia.org/wiki/Pixel_connectivity#3-dimensional">3-dimensional pixel connectivity</a>
  */
-public final class BucketFind {
-    private BucketFind() {
+public final class BucketScanner {
+    private BucketScanner() {
+    }
+
+    /**
+     * Finds any 6-connected blocks and puts them in a {@link LongSet}.
+     *
+     * @param origin   the position of the first block
+     * @param depth    the amount of maximum blocks to find
+     * @param ruleTest the rule test for the blocks that can be accepted in the set
+     */
+    public static LongSet findSix(BlockPos origin, int depth, RuleTest ruleTest, ServerWorld world, Random random) {
+        return findSix(origin, depth, pos -> ruleTest.test(world.getBlockState(pos), random));
+    }
+
+    /**
+     * Finds any 6-connected blocks and puts them in a {@link LongSet}.
+     *
+     * @param origin the position of the first block
+     * @param depth  the amount of maximum blocks to find
+     * @param tag    the tag for the blocks that can be accepted in the set
+     */
+    public static LongSet findSix(BlockPos origin, int depth, Tag<Block> tag, ServerWorld world) {
+        return findSix(origin, depth, pos -> world.getBlockState(pos).isIn(tag));
+    }
+
+    /**
+     * Finds any 6-connected blocks and puts them in a {@link LongSet}.
+     *
+     * @param origin the position of the first block
+     * @param depth  the amount of maximum blocks to find
+     * @param block  the block type that can be accepted in the set
+     */
+    public static LongSet findSix(BlockPos origin, int depth, Block block, ServerWorld world) {
+        return findSix(origin, depth, pos -> world.getBlockState(pos).isOf(block));
     }
 
     /**
@@ -29,7 +62,7 @@ public final class BucketFind {
      * @param depth     the amount of maximum blocks to find
      * @param predicate the predicate for the blocks that can be accepted in the set
      */
-    public static LongSet findSix(ServerWorld world, BlockPos origin, int depth, Predicate<BlockState> predicate) {
+    public static LongSet findSix(BlockPos origin, int depth, Predicate<BlockPos> predicate) {
         LongSet set = new LongArraySet();
         Deque<BlockPos> ends = new ArrayDeque<>();
         ends.push(origin);
@@ -41,7 +74,7 @@ public final class BucketFind {
             BlockPos pos = ends.pollLast();
             for(Direction direction : Direction.values()) {
                 local.set(pos.offset(direction));
-                if(predicate.test(world.getBlockState(local)) && !set.contains(local.asLong()) && !ends.contains(local)) {
+                if(predicate.test(local) && !set.contains(local.asLong()) && !ends.contains(local)) {
                     ends.push(local.toImmutable());
                 }
             }
@@ -52,36 +85,36 @@ public final class BucketFind {
     }
 
     /**
-     * Finds any 6-connected blocks and puts them in a {@link LongSet}.
+     * Finds any 18-connected blocks and puts them in a {@link LongSet}.
      *
      * @param origin   the position of the first block
      * @param depth    the amount of maximum blocks to find
      * @param ruleTest the rule test for the blocks that can be accepted in the set
      */
-    public static LongSet findSix(ServerWorld world, BlockPos origin, int depth, RuleTest ruleTest, Random random) {
-        return findSix(world, origin, depth, state -> ruleTest.test(state, random));
+    public static LongSet findEighteen(BlockPos origin, int depth, RuleTest ruleTest, ServerWorld world, Random random) {
+        return findEighteen(origin, depth, pos -> ruleTest.test(world.getBlockState(pos), random));
     }
 
     /**
-     * Finds any 6-connected blocks and puts them in a {@link LongSet}.
+     * Finds any 18-connected blocks and puts them in a {@link LongSet}.
      *
      * @param origin the position of the first block
      * @param depth  the amount of maximum blocks to find
      * @param tag    the tag for the blocks that can be accepted in the set
      */
-    public static LongSet findSix(ServerWorld world, BlockPos origin, int depth, Tag<Block> tag) {
-        return findSix(world, origin, depth, state -> state.isIn(tag));
+    public static LongSet findEighteen(BlockPos origin, int depth, Tag<Block> tag, ServerWorld world) {
+        return findEighteen(origin, depth, pos -> world.getBlockState(pos).isIn(tag));
     }
 
     /**
-     * Finds any 6-connected blocks and puts them in a {@link LongSet}.
+     * Finds any 18-connected blocks and puts them in a {@link LongSet}.
      *
      * @param origin the position of the first block
      * @param depth  the amount of maximum blocks to find
      * @param block  the block type that can be accepted in the set
      */
-    public static LongSet findSix(ServerWorld world, BlockPos origin, int depth, Block block) {
-        return findSix(world, origin, depth, state -> state.isOf(block));
+    public static LongSet findEighteen(BlockPos origin, int depth, Block block, ServerWorld world) {
+        return findEighteen(origin, depth, pos -> world.getBlockState(pos).isOf(block));
     }
 
     /**
@@ -91,7 +124,7 @@ public final class BucketFind {
      * @param depth     the amount of maximum blocks to find
      * @param predicate the predicate for the blocks that can be accepted in the set
      */
-    public static LongSet findEighteen(ServerWorld world, BlockPos origin, int depth, Predicate<BlockState> predicate) {
+    public static LongSet findEighteen(BlockPos origin, int depth, Predicate<BlockPos> predicate) {
         LongSet set = new LongArraySet();
         Deque<BlockPos> ends = new ArrayDeque<>();
         ends.push(origin);
@@ -103,22 +136,22 @@ public final class BucketFind {
             BlockPos pos = ends.pollLast();
             for(Direction direction : Direction.values()) {
                 local.set(pos.offset(direction));
-                if(predicate.test(world.getBlockState(local)) && !set.contains(local.asLong()) && !ends.contains(local)) {
+                if(predicate.test(local) && !set.contains(local.asLong()) && !ends.contains(local)) {
                     ends.push(local.toImmutable());
                 }
             }
             for(int i = -1; i <= 1; i += 2) {
                 for(int j = -1; j <= 1; j += 2) {
                     local.set(pos.add(i, j, 0));
-                    if(predicate.test(world.getBlockState(local)) && !set.contains(local.asLong()) && !ends.contains(local)) {
+                    if(predicate.test(local) && !set.contains(local.asLong()) && !ends.contains(local)) {
                         ends.push(local.toImmutable());
                     }
                     local.set(pos.add(0, i, j));
-                    if(predicate.test(world.getBlockState(local)) && !set.contains(local.asLong()) && !ends.contains(local)) {
+                    if(predicate.test(local) && !set.contains(local.asLong()) && !ends.contains(local)) {
                         ends.push(local.toImmutable());
                     }
                     local.set(pos.add(j, 0, i));
-                    if(predicate.test(world.getBlockState(local)) && !set.contains(local.asLong()) && !ends.contains(local)) {
+                    if(predicate.test(local) && !set.contains(local.asLong()) && !ends.contains(local)) {
                         ends.push(local.toImmutable());
                     }
                 }
@@ -130,36 +163,36 @@ public final class BucketFind {
     }
 
     /**
-     * Finds any 18-connected blocks and puts them in a {@link LongSet}.
+     * Finds any 26-connected blocks and puts them in a {@link LongSet}.
      *
      * @param origin   the position of the first block
      * @param depth    the amount of maximum blocks to find
      * @param ruleTest the rule test for the blocks that can be accepted in the set
      */
-    public static LongSet findEighteen(ServerWorld world, BlockPos origin, int depth, RuleTest ruleTest, Random random) {
-        return findEighteen(world, origin, depth, state -> ruleTest.test(state, random));
+    public static LongSet findTwentySix(BlockPos origin, int depth, RuleTest ruleTest, ServerWorld world, Random random) {
+        return findTwentySix(origin, depth, pos -> ruleTest.test(world.getBlockState(pos), random));
     }
 
     /**
-     * Finds any 18-connected blocks and puts them in a {@link LongSet}.
+     * Finds any 26-connected blocks and puts them in a {@link LongSet}.
      *
      * @param origin the position of the first block
      * @param depth  the amount of maximum blocks to find
      * @param tag    the tag for the blocks that can be accepted in the set
      */
-    public static LongSet findEighteen(ServerWorld world, BlockPos origin, int depth, Tag<Block> tag) {
-        return findEighteen(world, origin, depth, state -> state.isIn(tag));
+    public static LongSet findTwentySix(BlockPos origin, int depth, Tag<Block> tag, ServerWorld world) {
+        return findTwentySix(origin, depth, pos -> world.getBlockState(pos).isIn(tag));
     }
 
     /**
-     * Finds any 18-connected blocks and puts them in a {@link LongSet}.
+     * Finds any 26-connected blocks and puts them in a {@link LongSet}.
      *
      * @param origin the position of the first block
      * @param depth  the amount of maximum blocks to find
      * @param block  the block type that can be accepted in the set
      */
-    public static LongSet findEighteen(ServerWorld world, BlockPos origin, int depth, Block block) {
-        return findEighteen(world, origin, depth, state -> state.isOf(block));
+    public static LongSet findTwentySix(BlockPos origin, int depth, Block block, ServerWorld world) {
+        return findTwentySix(origin, depth, pos -> world.getBlockState(pos).isOf(block));
     }
 
     /**
@@ -169,7 +202,7 @@ public final class BucketFind {
      * @param depth     the amount of maximum blocks to find
      * @param predicate the predicate for the blocks that can be accepted in the set
      */
-    public static LongSet findTwentySix(ServerWorld world, BlockPos origin, int depth, Predicate<BlockState> predicate) {
+    public static LongSet findTwentySix(BlockPos origin, int depth, Predicate<BlockPos> predicate) {
         LongSet set = new LongArraySet();
         Deque<BlockPos> ends = new ArrayDeque<>();
         ends.push(origin);
@@ -184,7 +217,7 @@ public final class BucketFind {
                     for(int z = -1; z <= 1; z++) {
                         if(x == 0 && y == 0 && z == 0) continue;
                         local.set(pos.add(x, y, z));
-                        if(predicate.test(world.getBlockState(local)) && !set.contains(local.asLong()) && !ends.contains(local)) {
+                        if(predicate.test(local) && !set.contains(local.asLong()) && !ends.contains(local)) {
                             ends.push(local.toImmutable());
                         }
                     }
@@ -194,38 +227,5 @@ public final class BucketFind {
             depth--;
         }
         return set;
-    }
-
-    /**
-     * Finds any 26-connected blocks and puts them in a {@link LongSet}.
-     *
-     * @param origin   the position of the first block
-     * @param depth    the amount of maximum blocks to find
-     * @param ruleTest the rule test for the blocks that can be accepted in the set
-     */
-    public static LongSet findTwentySix(ServerWorld world, BlockPos origin, int depth, RuleTest ruleTest, Random random) {
-        return findTwentySix(world, origin, depth, state -> ruleTest.test(state, random));
-    }
-
-    /**
-     * Finds any 26-connected blocks and puts them in a {@link LongSet}.
-     *
-     * @param origin the position of the first block
-     * @param depth  the amount of maximum blocks to find
-     * @param tag    the tag for the blocks that can be accepted in the set
-     */
-    public static LongSet findTwentySix(ServerWorld world, BlockPos origin, int depth, Tag<Block> tag) {
-        return findTwentySix(world, origin, depth, state -> state.isIn(tag));
-    }
-
-    /**
-     * Finds any 26-connected blocks and puts them in a {@link LongSet}.
-     *
-     * @param origin the position of the first block
-     * @param depth  the amount of maximum blocks to find
-     * @param block  the block type that can be accepted in the set
-     */
-    public static LongSet findTwentySix(ServerWorld world, BlockPos origin, int depth, Block block) {
-        return findTwentySix(world, origin, depth, state -> state.isOf(block));
     }
 }

--- a/src/main/java/xyz/nucleoid/plasmid/util/BucketScanner.java
+++ b/src/main/java/xyz/nucleoid/plasmid/util/BucketScanner.java
@@ -14,218 +14,118 @@ import java.util.*;
 import java.util.function.Predicate;
 
 /**
- * Methods for finding connected blocks as a {@link LongSet}. Use {@link BlockPos#fromLong} to retrieve these positions.
- *
- * @see <a href="https://en.wikipedia.org/wiki/Pixel_connectivity#3-dimensional">3-dimensional pixel connectivity</a>
+ * Methods for finding connected blocks as a {@link LongSet}. Use {@link BlockPos#fromLong} to retrieve returned positions.
  */
 public final class BucketScanner {
     private BucketScanner() {
     }
 
     /**
-     * Finds any 6-connected blocks and puts them in a {@link LongSet}.
+     * Finds any connected blocks and puts them in a {@link LongSet}.
      *
-     * @param origin   the position of the first block
-     * @param depth    the amount of maximum blocks to find
-     * @param ruleTest the rule test for the blocks that can be accepted in the set
+     * @param origin       the position of the first block
+     * @param amount       the amount of maximum blocks to find
+     * @param connectivity the type of scan that should be used to find blocks around a branch end
+     * @param ruleTest     the rule test for the blocks that can be accepted in the set
      */
-    public static LongSet findSix(BlockPos origin, int depth, RuleTest ruleTest, ServerWorld world, Random random) {
-        return findSix(origin, depth, pos -> ruleTest.test(world.getBlockState(pos), random));
+    public static LongSet find(BlockPos origin, int amount, Connectivity connectivity, RuleTest ruleTest, ServerWorld world, Random random) {
+        return find(origin, amount, connectivity, pos -> ruleTest.test(world.getBlockState(pos), random));
     }
 
     /**
-     * Finds any 6-connected blocks and puts them in a {@link LongSet}.
+     * Finds any connected blocks and puts them in a {@link LongSet}.
      *
-     * @param origin the position of the first block
-     * @param depth  the amount of maximum blocks to find
-     * @param tag    the tag for the blocks that can be accepted in the set
+     * @param origin       the position of the first block
+     * @param amount       the amount of maximum blocks to find
+     * @param connectivity the type of scan that should be used to find blocks around a branch end
+     * @param tag          the tag for the blocks that can be accepted in the set
      */
-    public static LongSet findSix(BlockPos origin, int depth, Tag<Block> tag, ServerWorld world) {
-        return findSix(origin, depth, pos -> world.getBlockState(pos).isIn(tag));
+    public static LongSet find(BlockPos origin, int amount, Connectivity connectivity, Tag<Block> tag, ServerWorld world) {
+        return find(origin, amount, connectivity, pos -> world.getBlockState(pos).isIn(tag));
     }
 
     /**
-     * Finds any 6-connected blocks and puts them in a {@link LongSet}.
+     * Finds any connected blocks and puts them in a {@link LongSet}.
      *
-     * @param origin the position of the first block
-     * @param depth  the amount of maximum blocks to find
-     * @param block  the block type that can be accepted in the set
+     * @param origin       the position of the first block
+     * @param amount       the amount of maximum blocks to find
+     * @param connectivity the type of scan that should be used to find blocks around a branch end
+     * @param block        the block type that can be accepted in the set
      */
-    public static LongSet findSix(BlockPos origin, int depth, Block block, ServerWorld world) {
-        return findSix(origin, depth, pos -> world.getBlockState(pos).isOf(block));
+    public static LongSet find(BlockPos origin, int amount, Connectivity connectivity, Block block, ServerWorld world) {
+        return find(origin, amount, connectivity, pos -> world.getBlockState(pos).isOf(block));
     }
 
     /**
-     * Finds any 6-connected blocks and puts them in a {@link LongSet}.
+     * Finds any connected blocks and puts them in a {@link LongSet}.
      *
-     * @param origin    the position of the first block
-     * @param depth     the amount of maximum blocks to find
-     * @param predicate the predicate for the blocks that can be accepted in the set
+     * @param origin       the position of the first block
+     * @param amount       the amount of maximum blocks to find
+     * @param connectivity the type of scan that should be used to find blocks around a branch end
+     * @param predicate    the predicate for the blocks that can be accepted in the set
      */
-    public static LongSet findSix(BlockPos origin, int depth, Predicate<BlockPos> predicate) {
+    public static LongSet find(BlockPos origin, int amount, Connectivity connectivity, Predicate<BlockPos> predicate) {
         LongSet set = new LongArraySet();
         Deque<BlockPos> ends = new ArrayDeque<>();
         ends.push(origin);
-        BlockPos.Mutable local = origin.mutableCopy();
-        while(depth > 0) {
+        BlockPos.Mutable mutable = origin.mutableCopy();
+        while(amount > 0) {
             if(ends.isEmpty()) {
                 return set;
             }
             BlockPos pos = ends.pollLast();
-            for(Direction direction : Direction.values()) {
-                local.set(pos.offset(direction));
-                if(predicate.test(local) && !set.contains(local.asLong()) && !ends.contains(local)) {
-                    ends.push(local.toImmutable());
-                }
-            }
-            set.add(pos.asLong());
-            depth--;
-        }
-        return set;
-    }
-
-    /**
-     * Finds any 18-connected blocks and puts them in a {@link LongSet}.
-     *
-     * @param origin   the position of the first block
-     * @param depth    the amount of maximum blocks to find
-     * @param ruleTest the rule test for the blocks that can be accepted in the set
-     */
-    public static LongSet findEighteen(BlockPos origin, int depth, RuleTest ruleTest, ServerWorld world, Random random) {
-        return findEighteen(origin, depth, pos -> ruleTest.test(world.getBlockState(pos), random));
-    }
-
-    /**
-     * Finds any 18-connected blocks and puts them in a {@link LongSet}.
-     *
-     * @param origin the position of the first block
-     * @param depth  the amount of maximum blocks to find
-     * @param tag    the tag for the blocks that can be accepted in the set
-     */
-    public static LongSet findEighteen(BlockPos origin, int depth, Tag<Block> tag, ServerWorld world) {
-        return findEighteen(origin, depth, pos -> world.getBlockState(pos).isIn(tag));
-    }
-
-    /**
-     * Finds any 18-connected blocks and puts them in a {@link LongSet}.
-     *
-     * @param origin the position of the first block
-     * @param depth  the amount of maximum blocks to find
-     * @param block  the block type that can be accepted in the set
-     */
-    public static LongSet findEighteen(BlockPos origin, int depth, Block block, ServerWorld world) {
-        return findEighteen(origin, depth, pos -> world.getBlockState(pos).isOf(block));
-    }
-
-    /**
-     * Finds any 18-connected blocks and puts them in a {@link LongSet}..
-     *
-     * @param origin    the position of the first block
-     * @param depth     the amount of maximum blocks to find
-     * @param predicate the predicate for the blocks that can be accepted in the set
-     */
-    public static LongSet findEighteen(BlockPos origin, int depth, Predicate<BlockPos> predicate) {
-        LongSet set = new LongArraySet();
-        Deque<BlockPos> ends = new ArrayDeque<>();
-        ends.push(origin);
-        BlockPos.Mutable local = origin.mutableCopy();
-        while(depth > 0) {
-            if(ends.isEmpty()) {
-                return set;
-            }
-            BlockPos pos = ends.pollLast();
-            for(Direction direction : Direction.values()) {
-                local.set(pos.offset(direction));
-                if(predicate.test(local) && !set.contains(local.asLong()) && !ends.contains(local)) {
-                    ends.push(local.toImmutable());
-                }
-            }
-            for(int i = -1; i <= 1; i += 2) {
-                for(int j = -1; j <= 1; j += 2) {
-                    local.set(pos.add(i, j, 0));
-                    if(predicate.test(local) && !set.contains(local.asLong()) && !ends.contains(local)) {
-                        ends.push(local.toImmutable());
-                    }
-                    local.set(pos.add(0, i, j));
-                    if(predicate.test(local) && !set.contains(local.asLong()) && !ends.contains(local)) {
-                        ends.push(local.toImmutable());
-                    }
-                    local.set(pos.add(j, 0, i));
-                    if(predicate.test(local) && !set.contains(local.asLong()) && !ends.contains(local)) {
-                        ends.push(local.toImmutable());
-                    }
-                }
-            }
-            set.add(pos.asLong());
-            depth--;
-        }
-        return set;
-    }
-
-    /**
-     * Finds any 26-connected blocks and puts them in a {@link LongSet}.
-     *
-     * @param origin   the position of the first block
-     * @param depth    the amount of maximum blocks to find
-     * @param ruleTest the rule test for the blocks that can be accepted in the set
-     */
-    public static LongSet findTwentySix(BlockPos origin, int depth, RuleTest ruleTest, ServerWorld world, Random random) {
-        return findTwentySix(origin, depth, pos -> ruleTest.test(world.getBlockState(pos), random));
-    }
-
-    /**
-     * Finds any 26-connected blocks and puts them in a {@link LongSet}.
-     *
-     * @param origin the position of the first block
-     * @param depth  the amount of maximum blocks to find
-     * @param tag    the tag for the blocks that can be accepted in the set
-     */
-    public static LongSet findTwentySix(BlockPos origin, int depth, Tag<Block> tag, ServerWorld world) {
-        return findTwentySix(origin, depth, pos -> world.getBlockState(pos).isIn(tag));
-    }
-
-    /**
-     * Finds any 26-connected blocks and puts them in a {@link LongSet}.
-     *
-     * @param origin the position of the first block
-     * @param depth  the amount of maximum blocks to find
-     * @param block  the block type that can be accepted in the set
-     */
-    public static LongSet findTwentySix(BlockPos origin, int depth, Block block, ServerWorld world) {
-        return findTwentySix(origin, depth, pos -> world.getBlockState(pos).isOf(block));
-    }
-
-    /**
-     * Finds any 26-connected blocks and puts them in a {@link LongSet}.
-     *
-     * @param origin    the position of the first block
-     * @param depth     the amount of maximum blocks to find
-     * @param predicate the predicate for the blocks that can be accepted in the set
-     */
-    public static LongSet findTwentySix(BlockPos origin, int depth, Predicate<BlockPos> predicate) {
-        LongSet set = new LongArraySet();
-        Deque<BlockPos> ends = new ArrayDeque<>();
-        ends.push(origin);
-        BlockPos.Mutable local = origin.mutableCopy();
-        while(depth > 0) {
-            if(ends.isEmpty()) {
-                return set;
-            }
-            BlockPos pos = ends.pollLast();
-            for(int x = -1; x <= 1; x++) {
-                for(int y = -1; y <= 1; y++) {
-                    for(int z = -1; z <= 1; z++) {
-                        if(x == 0 && y == 0 && z == 0) continue;
-                        local.set(pos.add(x, y, z));
-                        if(predicate.test(local) && !set.contains(local.asLong()) && !ends.contains(local)) {
-                            ends.push(local.toImmutable());
+            switch(connectivity) {
+                case EIGHTEEN:
+                    for(int i = -1; i <= 1; i += 2) {
+                        for(int j = -1; j <= 1; j += 2) {
+                            mutable.set(pos.add(i, j, 0));
+                            if(predicate.test(mutable) && !set.contains(mutable.asLong()) && !ends.contains(mutable)) {
+                                ends.push(mutable.toImmutable());
+                            }
+                            mutable.set(pos.add(0, i, j));
+                            if(predicate.test(mutable) && !set.contains(mutable.asLong()) && !ends.contains(mutable)) {
+                                ends.push(mutable.toImmutable());
+                            }
+                            mutable.set(pos.add(j, 0, i));
+                            if(predicate.test(mutable) && !set.contains(mutable.asLong()) && !ends.contains(mutable)) {
+                                ends.push(mutable.toImmutable());
+                            }
                         }
                     }
-                }
+                case SIX:
+                    for(Direction direction : Direction.values()) {
+                        mutable.set(pos.offset(direction));
+                        if(predicate.test(mutable) && !set.contains(mutable.asLong()) && !ends.contains(mutable)) {
+                            ends.push(mutable.toImmutable());
+                        }
+                    }
+                    break;
+                case TWENTY_SIX:
+                    for(int x = -1; x <= 1; x++) {
+                        for(int y = -1; y <= 1; y++) {
+                            for(int z = -1; z <= 1; z++) {
+                                if(x == 0 && y == 0 && z == 0) continue;
+                                mutable.set(pos.add(x, y, z));
+                                if(predicate.test(mutable) && !set.contains(mutable.asLong()) && !ends.contains(mutable)) {
+                                    ends.push(mutable.toImmutable());
+                                }
+                            }
+                        }
+                    }
+                    break;
             }
             set.add(pos.asLong());
-            depth--;
+            amount--;
         }
         return set;
+    }
+
+    /**
+     * @see <a href="https://en.wikipedia.org/wiki/Pixel_connectivity#3-dimensional">3-dimensional pixel connectivity</a>
+     */
+    public enum Connectivity {
+        SIX,
+        EIGHTEEN,
+        TWENTY_SIX
     }
 }

--- a/src/main/java/xyz/nucleoid/plasmid/util/BucketScanner.java
+++ b/src/main/java/xyz/nucleoid/plasmid/util/BucketScanner.java
@@ -24,54 +24,21 @@ public final class BucketScanner {
     /**
      * Finds any connected blocks and puts them in a {@link LongSet}.
      *
-     * @param origin   the position of the first block
-     * @param amount   the amount of maximum blocks to find
-     * @param ruleTest the rule test for the blocks that can be accepted in the set
-     */
-    public static LongSet find(BlockPos origin, Type depth, Connectivity connectivity, int amount, RuleTest ruleTest, ServerWorld world, Random random) {
-        return find(origin, depth, connectivity, amount, pos -> ruleTest.test(world.getBlockState(pos), random));
-    }
-
-    /**
-     * Finds any connected blocks and puts them in a {@link LongSet}.
-     *
      * @param origin the position of the first block
      * @param amount the amount of maximum blocks to find
-     * @param tag    the tag for the blocks that can be accepted in the set
-     */
-    public static LongSet find(BlockPos origin, Type depth, Connectivity connectivity, int amount, Tag<Block> tag, ServerWorld world) {
-        return find(origin, depth, connectivity, amount, pos -> world.getBlockState(pos).isIn(tag));
-    }
-
-    /**
-     * Finds any connected blocks and puts them in a {@link LongSet}.
-     *
-     * @param origin the position of the first block
-     * @param amount the amount of maximum blocks to find
-     * @param block  the block type that can be accepted in the set
-     */
-    public static LongSet find(BlockPos origin, Type depth, Connectivity connectivity, int amount, Block block, ServerWorld world) {
-        return find(origin, depth, connectivity, amount, pos -> world.getBlockState(pos).isOf(block));
-    }
-
-    /**
-     * Finds any connected blocks and puts them in a {@link LongSet}.
-     *
-     * @param origin    the position of the first block
-     * @param amount    the amount of maximum blocks to find
      * @param predicate the predicate for the blocks that can be accepted in the set
      */
-    public static LongSet find(BlockPos origin, Type depth, Connectivity connectivity, int amount, Predicate<BlockPos> predicate) {
+    public static LongSet find(BlockPos origin, int amount, Connectivity connectivity, Type depth, Predicate<BlockPos> predicate) {
         LongSet set = new LongArraySet();
         Deque<BlockPos> ends = new ArrayDeque<>();
         ends.push(origin);
         BlockPos.Mutable mutable = origin.mutableCopy();
-        while(amount > 0) {
-            if(ends.isEmpty()) {
+        while (amount > 0) {
+            if (ends.isEmpty()) {
                 return set;
             }
             BlockPos pos;
-            switch(depth) {
+            switch (depth) {
                 case BREADTH:
                 default:
                     pos = ends.pollLast();
@@ -80,25 +47,25 @@ public final class BucketScanner {
                     pos = ends.pollFirst();
                     break;
             }
-            if(connectivity == Connectivity.TWENTY_SIX) {
-                for(int i = -1; i <= 1; i += 2) {
-                    for(int j = -1; j <= 1; j += 2) {
-                        for(int k = -1; k <= 1; k += 2) {
+            if (connectivity == Connectivity.TWENTY_SIX) {
+                for (int i = -1; i <= 1; i += 2) {
+                    for (int j = -1; j <= 1; j += 2) {
+                        for (int k = -1; k <= 1; k += 2) {
                             scan(mutable.set(pos.add(i, j, k)), set, ends, predicate);
                         }
                     }
                 }
             }
-            if(connectivity != Connectivity.SIX) {
-                for(int i = -1; i <= 1; i += 2) {
-                    for(int j = -1; j <= 1; j += 2) {
+            if (connectivity != Connectivity.SIX) {
+                for (int i = -1; i <= 1; i += 2) {
+                    for (int j = -1; j <= 1; j += 2) {
                         scan(mutable.set(pos.add(i, j, 0)), set, ends, predicate);
                         scan(mutable.set(pos.add(0, i, j)), set, ends, predicate);
                         scan(mutable.set(pos.add(j, 0, i)), set, ends, predicate);
                     }
                 }
             }
-            for(Direction direction : Direction.values()) {
+            for (Direction direction : Direction.values()) {
                 scan(mutable.set(pos.offset(direction)), set, ends, predicate);
             }
             set.add(pos.asLong());
@@ -107,8 +74,41 @@ public final class BucketScanner {
         return set;
     }
 
+    /**
+     * Finds any connected blocks and puts them in a {@link LongSet}.
+     *
+     * @param origin the position of the first block
+     * @param amount the amount of maximum blocks to find
+     * @param block the block type that can be accepted in the set
+     */
+    public static LongSet find(BlockPos origin, int amount, Connectivity connectivity, Type depth, Block block, ServerWorld world) {
+        return find(origin, amount, connectivity, depth, pos -> world.getBlockState(pos).isOf(block));
+    }
+
+    /**
+     * Finds any connected blocks and puts them in a {@link LongSet}.
+     *
+     * @param origin the position of the first block
+     * @param amount the amount of maximum blocks to find
+     * @param tag the tag for the blocks that can be accepted in the set
+     */
+    public static LongSet find(BlockPos origin, int amount, Connectivity connectivity, Type depth, Tag<Block> tag, ServerWorld world) {
+        return find(origin, amount, connectivity, depth, pos -> world.getBlockState(pos).isIn(tag));
+    }
+
+    /**
+     * Finds any connected blocks and puts them in a {@link LongSet}.
+     *
+     * @param origin the position of the first block
+     * @param amount the amount of maximum blocks to find
+     * @param ruleTest the rule test for the blocks that can be accepted in the set
+     */
+    public static LongSet find(BlockPos origin, int amount, Connectivity connectivity, Type depth, RuleTest ruleTest, ServerWorld world, Random random) {
+        return find(origin, amount, connectivity, depth, pos -> ruleTest.test(world.getBlockState(pos), random));
+    }
+
     private static void scan(BlockPos.Mutable mutable, LongSet set, Deque<BlockPos> ends, Predicate<BlockPos> predicate) {
-        if(predicate.test(mutable) && !set.contains(mutable.asLong()) && !ends.contains(mutable)) {
+        if (predicate.test(mutable) && !set.contains(mutable.asLong()) && !ends.contains(mutable)) {
             ends.push(mutable.toImmutable());
         }
     }

--- a/src/main/java/xyz/nucleoid/plasmid/util/BucketScanner.java
+++ b/src/main/java/xyz/nucleoid/plasmid/util/BucketScanner.java
@@ -11,123 +11,148 @@ import net.minecraft.util.math.Direction;
 
 import java.util.*;
 import java.util.function.BiPredicate;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
 
 /**
  * Methods for finding connected blocks as a {@link LongSet}. Use {@link BlockPos#fromLong} to retrieve returned positions.
  */
 public final class BucketScanner {
-    private final LongSet set;
-    private final Deque<Long> ends;
-    private final Map<Long, Integer> endDepthMap;
-
     private final Builder builder;
-    private final BlockPos.Mutable mutable;
+
+    private final Map<Long, Integer> depthMap;
+
+    private final Deque<Long> scanQueue;
+    private final BlockPos.Mutable previousMutable;
+    private final BlockPos.Mutable nextMutable;
 
     private BucketScanner(Builder builder, BlockPos origin) {
-        this.set = new LongArraySet();
-        this.ends = new ArrayDeque<>();
-        this.endDepthMap = new HashMap<>();
-
         this.builder = builder;
-        this.mutable = origin.mutableCopy();
+        this.depthMap = new HashMap<>();
 
-        this.ends.push(origin.asLong());
-        this.endDepthMap.put(origin.asLong(), builder.maxDepth);
+        this.scanQueue = new ArrayDeque<>();
+        this.previousMutable = origin.mutableCopy();
+        this.nextMutable = origin.mutableCopy();
 
-        this.scan();
+        scanQueue.push(origin.asLong());
+        depthMap.put(origin.asLong(), builder.maxDepth);
+
+        this.initialize();
     }
 
     /**
+     * Creates a bucket scanner builder.
+     *
      * @param predicate the predicate for the blocks that can be accepted in the set
+     * @return a new bucket scanner builder
      */
-    public static Builder create(BiPredicate<BlockPos, BlockPos> predicate) {
+    public static Builder create(ScanPredicate predicate) {
         return new Builder(predicate, Connectivity.SIX, SearchType.DEPTH_FIRST, 512, -1);
     }
 
     /**
+     * Creates a bucket scanner builder.
+     *
      * @param block the block type that can be accepted in the set
+     * @return a new bucket scanner builder
      */
     public static Builder create(Block block, ServerWorld world) {
-        return create((previousPos, pos) -> world.getBlockState(pos).isOf(block));
+        return create((previousPos, nextPos) -> world.getBlockState(nextPos).isOf(block));
     }
 
     /**
+     * Creates a bucket scanner builder.
+     *
      * @param tag the tag for the blocks that can be accepted in the set
+     * @return a new bucket scanner builder
      */
     public static Builder create(Tag<Block> tag, ServerWorld world) {
         return create((previousPos, pos) -> world.getBlockState(pos).isIn(tag));
     }
 
     /**
+     * Creates a bucket scanner builder.
+     *
      * @param ruleTest the rule test for the blocks that can be accepted in the set
+     * @return a new bucket scanner builder
      */
     public static Builder create(RuleTest ruleTest, ServerWorld world, Random random) {
-        return create((previousPos, pos) -> ruleTest.test(world.getBlockState(pos), random));
+        return create((previousPos, nextPos) -> ruleTest.test(world.getBlockState(nextPos), random));
     }
 
-    private void scan() {
+    private void initialize() {
         int amount = 1;
-        while (amount != this.builder.maxAmount) {
-            if (this.ends.isEmpty()) {
+        while(amount != builder.maxAmount) {
+            if(scanQueue.isEmpty()) {
                 return;
             }
             long pos;
-            switch (this.builder.searchType) {
+            switch(builder.searchType) {
                 case BREADTH_FIRST:
                 default:
-                    pos = this.ends.pollLast();
+                    pos = scanQueue.pollLast();
                     break;
                 case DEPTH_FIRST:
-                    pos = this.ends.pollFirst();
+                    pos = scanQueue.pollFirst();
                     break;
             }
-            if (this.builder.connectivity == Connectivity.TWENTY_SIX) {
-                for (int i = -1; i <= 1; i += 2) {
-                    for (int j = -1; j <= 1; j += 2) {
-                        for (int k = -1; k <= 1; k += 2) {
-                            this.scan(pos, i, j, k);
+            if(builder.connectivity == Connectivity.TWENTY_SIX) {
+                for(int i = -1; i <= 1; i += 2) {
+                    for(int j = -1; j <= 1; j += 2) {
+                        for(int k = -1; k <= 1; k += 2) {
+                            scan(pos, i, j, k);
                         }
                     }
                 }
             }
-            if (this.builder.connectivity != Connectivity.SIX) {
-                for (int i = -1; i <= 1; i += 2) {
-                    for (int j = -1; j <= 1; j += 2) {
-                        this.scan(pos, i, j, 0);
-                        this.scan(pos, 0, i, j);
-                        this.scan(pos, j, 0, i);
+            if(builder.connectivity != Connectivity.SIX) {
+                for(int i = -1; i <= 1; i += 2) {
+                    for(int j = -1; j <= 1; j += 2) {
+                        scan(pos, i, j, 0);
+                        scan(pos, 0, i, j);
+                        scan(pos, j, 0, i);
                     }
                 }
             }
-            for (Direction direction : Direction.values()) {
-                this.scan(pos, direction.getOffsetX(), direction.getOffsetY(), direction.getOffsetZ());
+            for(Direction direction : Direction.values()) {
+                scan(pos, direction.getOffsetX(), direction.getOffsetY(), direction.getOffsetZ());
             }
-            this.set.add(pos);
             amount++;
         }
     }
 
     private void scan(long previousLong, int offsetX, int offsetY, int offsetZ) {
-        BlockPos previousPos = BlockPos.fromLong(previousLong);
-        this.mutable.set(previousPos.getX() + offsetX, previousPos.getY() + offsetY, previousPos.getZ() + offsetZ);
-        if (this.test(previousPos, this.mutable, this.set, this.ends)) {
-            long offsetLong = this.mutable.asLong();
-            int depth = this.endDepthMap.get(previousLong) - 1;
-            if (depth > 0) {
-                this.ends.push(offsetLong);
-                this.endDepthMap.put(offsetLong, depth);
-            } else {
-                this.set.add(offsetLong);
+        this.previousMutable.set(previousLong);
+        this.nextMutable.set(previousLong).move(offsetX, offsetY, offsetZ);
+        if(test(previousMutable, nextMutable)) {
+            long nextLong = nextMutable.asLong();
+            int nextDepth = depthMap.get(previousLong) - 1;
+            if(nextDepth > 0) {
+                scanQueue.push(nextLong);
             }
+            depthMap.put(nextLong, nextDepth);
         }
     }
 
-    private boolean test(BlockPos previousPos, BlockPos offsetPos, LongSet set, Deque<Long> ends) {
-        return this.builder.predicate.test(previousPos, offsetPos) && !set.contains(offsetPos.asLong()) && !ends.contains(offsetPos.asLong());
+    private boolean test(BlockPos previousPos, BlockPos nextPos) {
+        return this.builder.predicate.test(previousPos, nextPos) && !depthMap.containsKey(nextPos.asLong()) && !scanQueue.contains(nextPos.asLong());
     }
 
+    /**
+     * @return the set of positions found by the scanner
+     */
     public LongSet getPositions() {
-        return this.set;
+        return new LongArraySet(depthMap.keySet());
+    }
+
+    /**
+     * Gives a set of positions depending on the depth values of those positions.
+     *
+     * @param predicate determines if a position should enter the set depending of its depth value
+     * @return the set of positions found by the scanner that verify the predicate
+     */
+    public LongSet getPositions(Predicate<Integer> predicate) {
+        return new LongArraySet(depthMap.entrySet().stream().filter(entry -> predicate.test(entry.getValue())).mapToLong(Map.Entry::getKey).boxed().collect(Collectors.toSet()));
     }
 
     public enum Connectivity {
@@ -141,14 +166,25 @@ public final class BucketScanner {
         DEPTH_FIRST
     }
 
+    @FunctionalInterface
+    public interface ScanPredicate {
+        /**
+         * Method executed at each branch end to fuel the scanning process and spread around.
+         *
+         * @param previousPos the position of a branch end
+         * @param nextPos     the position of the block being scanned next to the branch end
+         */
+        boolean test(BlockPos previousPos, BlockPos nextPos);
+    }
+
     public static class Builder {
-        private final BiPredicate<BlockPos, BlockPos> predicate;
+        private final ScanPredicate predicate;
         private int maxAmount;
         private int maxDepth;
         private Connectivity connectivity;
         private SearchType searchType;
 
-        private Builder(BiPredicate<BlockPos, BlockPos> predicate, Connectivity connectivity, SearchType searchType, int maxDepth, int maxAmount) {
+        private Builder(ScanPredicate predicate, Connectivity connectivity, SearchType searchType, int maxDepth, int maxAmount) {
             this.maxAmount = maxAmount;
             this.maxDepth = maxDepth;
             this.connectivity = connectivity;
@@ -158,6 +194,10 @@ public final class BucketScanner {
 
         /**
          * The maximum amount of blocks that can be scanned.
+         * <p>Set to -1 to disable this.
+         * <p>Is set to -1 by default.
+         *
+         * @return this builder for chaining
          */
         public Builder maxAmount(int max) {
             this.maxAmount = max;
@@ -166,13 +206,21 @@ public final class BucketScanner {
 
         /**
          * The maximum length of branches that can be scanned.
+         * <p>Cannot be set to a value under 0.
+         * <p>Is set to 512 by default.
+         *
+         * @return this builder for chaining
          */
         public Builder maxDepth(int max) {
-            this.maxDepth = max;
+            this.maxDepth = Math.max(max, 0);
             return this;
         }
 
         /**
+         * The type of connectivity to use to search blocks around a branch end.
+         * Is set to {@link Connectivity#SIX} by default.
+         *
+         * @return this builder for chaining
          * @see <a href="https://en.wikipedia.org/wiki/Pixel_connectivity#3-dimensional">3-dimensional pixel connectivity</a>
          */
         public Builder connectivity(Connectivity c) {
@@ -181,6 +229,9 @@ public final class BucketScanner {
         }
 
         /**
+         * Is set to {@link SearchType#DEPTH_FIRST} by default.
+         *
+         * @return this builder for chaining
          * @see <a href="https://en.wikipedia.org/wiki/Breadth-first_search">Breadth-first search</a>
          * @see <a href="https://en.wikipedia.org/wiki/Depth-first_search">Depth-first search</a>
          */
@@ -189,6 +240,12 @@ public final class BucketScanner {
             return this;
         }
 
+        /**
+         * Executes the scanning process.
+         *
+         * @param origin the origin position of the scan
+         * @return a new {@link BucketScanner}
+         */
         public BucketScanner build(BlockPos origin) {
             return new BucketScanner(this, origin);
         }

--- a/src/main/java/xyz/nucleoid/plasmid/util/BucketScanner.java
+++ b/src/main/java/xyz/nucleoid/plasmid/util/BucketScanner.java
@@ -9,125 +9,188 @@ import net.minecraft.tag.Tag;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Direction;
 
-import java.util.ArrayDeque;
-import java.util.Deque;
-import java.util.Random;
+import java.util.*;
 import java.util.function.BiPredicate;
 
 /**
  * Methods for finding connected blocks as a {@link LongSet}. Use {@link BlockPos#fromLong} to retrieve returned positions.
  */
 public final class BucketScanner {
-    private BucketScanner() {
+    private final LongSet set;
+    private final Deque<Long> ends;
+    private final Map<Long, Integer> endDepthMap;
+
+    private final Builder builder;
+    private final BlockPos.Mutable mutable;
+
+    private BucketScanner(Builder builder, BlockPos origin) {
+        this.set = new LongArraySet();
+        this.ends = new ArrayDeque<>();
+        this.endDepthMap = new HashMap<>();
+
+        this.builder = builder;
+        this.mutable = origin.mutableCopy();
+
+        this.ends.push(origin.asLong());
+        this.endDepthMap.put(origin.asLong(), builder.maxDepth);
+
+        this.scan();
     }
 
     /**
-     * Finds any connected blocks and puts them in a {@link LongSet}.
-     *
-     * @param origin the position of the first block
-     * @param amount the amount of maximum blocks to find
      * @param predicate the predicate for the blocks that can be accepted in the set
      */
-    public static LongSet find(BlockPos origin, int amount, Connectivity connectivity, Type depth, BiPredicate<BlockPos, BlockPos> predicate) {
-        LongSet set = new LongArraySet();
-        Deque<BlockPos> ends = new ArrayDeque<>();
-        ends.push(origin);
-        BlockPos.Mutable mutable = origin.mutableCopy();
-        while (amount > 0) {
-            if (ends.isEmpty()) {
-                return set;
+    public static Builder create(BiPredicate<BlockPos, BlockPos> predicate) {
+        return new Builder(predicate, Connectivity.SIX, SearchType.DEPTH_FIRST, 512, -1);
+    }
+
+    /**
+     * @param block the block type that can be accepted in the set
+     */
+    public static Builder create(Block block, ServerWorld world) {
+        return create((previousPos, pos) -> world.getBlockState(pos).isOf(block));
+    }
+
+    /**
+     * @param tag the tag for the blocks that can be accepted in the set
+     */
+    public static Builder create(Tag<Block> tag, ServerWorld world) {
+        return create((previousPos, pos) -> world.getBlockState(pos).isIn(tag));
+    }
+
+    /**
+     * @param ruleTest the rule test for the blocks that can be accepted in the set
+     */
+    public static Builder create(RuleTest ruleTest, ServerWorld world, Random random) {
+        return create((previousPos, pos) -> ruleTest.test(world.getBlockState(pos), random));
+    }
+
+    private void scan() {
+        int amount = 1;
+        while (amount != this.builder.maxAmount) {
+            if (this.ends.isEmpty()) {
+                return;
             }
-            BlockPos pos;
-            switch (depth) {
-                case BREADTH:
+            long pos;
+            switch (this.builder.searchType) {
+                case BREADTH_FIRST:
                 default:
-                    pos = ends.pollLast();
+                    pos = this.ends.pollLast();
                     break;
-                case DEPTH:
-                    pos = ends.pollFirst();
+                case DEPTH_FIRST:
+                    pos = this.ends.pollFirst();
                     break;
             }
-            if (connectivity == Connectivity.TWENTY_SIX) {
+            if (this.builder.connectivity == Connectivity.TWENTY_SIX) {
                 for (int i = -1; i <= 1; i += 2) {
                     for (int j = -1; j <= 1; j += 2) {
                         for (int k = -1; k <= 1; k += 2) {
-                            scan(pos, mutable.set(pos.add(i, j, k)), set, ends, predicate);
+                            this.scan(pos, i, j, k);
                         }
                     }
                 }
             }
-            if (connectivity != Connectivity.SIX) {
+            if (this.builder.connectivity != Connectivity.SIX) {
                 for (int i = -1; i <= 1; i += 2) {
                     for (int j = -1; j <= 1; j += 2) {
-                        scan(pos, mutable.set(pos.add(i, j, 0)), set, ends, predicate);
-                        scan(pos, mutable.set(pos.add(0, i, j)), set, ends, predicate);
-                        scan(pos, mutable.set(pos.add(j, 0, i)), set, ends, predicate);
+                        this.scan(pos, i, j, 0);
+                        this.scan(pos, 0, i, j);
+                        this.scan(pos, j, 0, i);
                     }
                 }
             }
             for (Direction direction : Direction.values()) {
-                scan(pos, mutable.set(pos.offset(direction)), set, ends, predicate);
+                this.scan(pos, direction.getOffsetX(), direction.getOffsetY(), direction.getOffsetZ());
             }
-            set.add(pos.asLong());
-            amount--;
-        }
-        return set;
-    }
-
-    /**
-     * Finds any connected blocks and puts them in a {@link LongSet}.
-     *
-     * @param origin the position of the first block
-     * @param amount the amount of maximum blocks to find
-     * @param block the block type that can be accepted in the set
-     */
-    public static LongSet find(BlockPos origin, int amount, Connectivity connectivity, Type depth, Block block, ServerWorld world) {
-        return find(origin, amount, connectivity, depth, (previousPos, pos) -> world.getBlockState(pos).isOf(block));
-    }
-
-    /**
-     * Finds any connected blocks and puts them in a {@link LongSet}.
-     *
-     * @param origin the position of the first block
-     * @param amount the amount of maximum blocks to find
-     * @param tag the tag for the blocks that can be accepted in the set
-     */
-    public static LongSet find(BlockPos origin, int amount, Connectivity connectivity, Type depth, Tag<Block> tag, ServerWorld world) {
-        return find(origin, amount, connectivity, depth, (previousPos, pos) -> world.getBlockState(pos).isIn(tag));
-    }
-
-    /**
-     * Finds any connected blocks and puts them in a {@link LongSet}.
-     *
-     * @param origin the position of the first block
-     * @param amount the amount of maximum blocks to find
-     * @param ruleTest the rule test for the blocks that can be accepted in the set
-     */
-    public static LongSet find(BlockPos origin, int amount, Connectivity connectivity, Type depth, RuleTest ruleTest, ServerWorld world, Random random) {
-        return find(origin, amount, connectivity, depth, (previousPos, pos) -> ruleTest.test(world.getBlockState(pos), random));
-    }
-
-    private static void scan(BlockPos previousPos, BlockPos.Mutable mutable, LongSet set, Deque<BlockPos> ends, BiPredicate<BlockPos, BlockPos> predicate) {
-        if (predicate.test(previousPos, mutable) && !set.contains(mutable.asLong()) && !ends.contains(mutable)) {
-            ends.push(mutable.toImmutable());
+            this.set.add(pos);
+            amount++;
         }
     }
 
-    /**
-     * @see <a href="https://en.wikipedia.org/wiki/Pixel_connectivity#3-dimensional">3-dimensional pixel connectivity</a>
-     */
+    private void scan(long previousLong, int offsetX, int offsetY, int offsetZ) {
+        BlockPos previousPos = BlockPos.fromLong(previousLong);
+        this.mutable.set(previousPos.getX() + offsetX, previousPos.getY() + offsetY, previousPos.getZ() + offsetZ);
+        if (this.test(previousPos, this.mutable, this.set, this.ends)) {
+            long offsetLong = this.mutable.asLong();
+            int depth = this.endDepthMap.get(previousLong) - 1;
+            if (depth > 0) {
+                this.ends.push(offsetLong);
+                this.endDepthMap.put(offsetLong, depth);
+            } else {
+                this.set.add(offsetLong);
+            }
+        }
+    }
+
+    private boolean test(BlockPos previousPos, BlockPos offsetPos, LongSet set, Deque<Long> ends) {
+        return this.builder.predicate.test(previousPos, offsetPos) && !set.contains(offsetPos.asLong()) && !ends.contains(offsetPos.asLong());
+    }
+
+    public LongSet getPositions() {
+        return this.set;
+    }
+
     public enum Connectivity {
         SIX,
         EIGHTEEN,
         TWENTY_SIX
     }
 
-    /**
-     * @see <a href="https://en.wikipedia.org/wiki/Breadth-first_search">Breadth-first search</a>
-     * @see <a href="https://en.wikipedia.org/wiki/Depth-first_search">Depth-first search</a>
-     */
-    public enum Type {
-        BREADTH,
-        DEPTH
+    public enum SearchType {
+        BREADTH_FIRST,
+        DEPTH_FIRST
+    }
+
+    public static class Builder {
+        private final BiPredicate<BlockPos, BlockPos> predicate;
+        private int maxAmount;
+        private int maxDepth;
+        private Connectivity connectivity;
+        private SearchType searchType;
+
+        private Builder(BiPredicate<BlockPos, BlockPos> predicate, Connectivity connectivity, SearchType searchType, int maxDepth, int maxAmount) {
+            this.maxAmount = maxAmount;
+            this.maxDepth = maxDepth;
+            this.connectivity = connectivity;
+            this.searchType = searchType;
+            this.predicate = predicate;
+        }
+
+        /**
+         * The maximum amount of blocks that can be scanned.
+         */
+        public Builder maxAmount(int max) {
+            this.maxAmount = max;
+            return this;
+        }
+
+        /**
+         * The maximum length of branches that can be scanned.
+         */
+        public Builder maxDepth(int max) {
+            this.maxDepth = max;
+            return this;
+        }
+
+        /**
+         * @see <a href="https://en.wikipedia.org/wiki/Pixel_connectivity#3-dimensional">3-dimensional pixel connectivity</a>
+         */
+        public Builder connectivity(Connectivity c) {
+            this.connectivity = c;
+            return this;
+        }
+
+        /**
+         * @see <a href="https://en.wikipedia.org/wiki/Breadth-first_search">Breadth-first search</a>
+         * @see <a href="https://en.wikipedia.org/wiki/Depth-first_search">Depth-first search</a>
+         */
+        public Builder searchType(SearchType s) {
+            this.searchType = s;
+            return this;
+        }
+
+        public BucketScanner build(BlockPos origin) {
+            return new BucketScanner(this, origin);
+        }
     }
 }


### PR DESCRIPTION
In a similar fashion as a bucket tool in painting programs, this class allow to detect all the blocks of a tag that are directly connected to a first block position. This allows for fast tree/ore veins destroying.

(PORTED from [BwActive](https://github.com/NucleoidMC/bed-wars/blob/1.16/src/main/java/xyz/nucleoid/bedwars/game/active/BwActive.java))