### PR TITLE
Update MenuPortal to match changes in GameConfig and few other things

### DIFF
--- a/src/main/java/xyz/nucleoid/plasmid/command/ui/GameJoinUi.java
+++ b/src/main/java/xyz/nucleoid/plasmid/command/ui/GameJoinUi.java
@@ -56,12 +56,6 @@ public class GameJoinUi extends SimpleGui {
         var games = new ArrayList<>(GameSpaceManager.get().getOpenGameSpaces());
         games.sort(Comparator.comparingInt(space -> space.getPlayers().size()));
 
-        if (games.size() != 0) {
-            for (int x = 0; x < 183; x++) {
-                games.add(games.get(0));
-            }
-        }
-
         int limit = this.size;
         this.pageSize = 0;
 

--- a/src/main/java/xyz/nucleoid/plasmid/command/ui/GameJoinUi.java
+++ b/src/main/java/xyz/nucleoid/plasmid/command/ui/GameJoinUi.java
@@ -1,28 +1,43 @@
 package xyz.nucleoid.plasmid.command.ui;
 
 import eu.pb4.sgui.api.elements.GuiElementBuilder;
+import eu.pb4.sgui.api.elements.GuiElementInterface;
 import eu.pb4.sgui.api.gui.SimpleGui;
+import net.minecraft.item.Items;
 import net.minecraft.screen.ScreenHandlerType;
 import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.text.LiteralText;
 import net.minecraft.text.TranslatableText;
 import net.minecraft.util.Formatting;
+import net.minecraft.util.math.MathHelper;
 import xyz.nucleoid.plasmid.game.GameSpace;
 import xyz.nucleoid.plasmid.game.manager.GameSpaceManager;
 import xyz.nucleoid.plasmid.game.manager.ManagedGameSpace;
 import xyz.nucleoid.plasmid.game.player.GamePlayerJoiner;
+import xyz.nucleoid.plasmid.util.Guis;
 
 import java.util.ArrayList;
 import java.util.Comparator;
 
-// Todo: Maybe add paging support?
 public class GameJoinUi extends SimpleGui {
+    private static final GuiElementInterface EMPTY = new GuiElementBuilder(Items.GRAY_STAINED_GLASS_PANE).setName(LiteralText.EMPTY.copy()).build();
+
+    private static final int NAVBAR_POS = 81;
     private int tick;
+    private int page = 0;
+    private int pageSize;
 
     public GameJoinUi(ServerPlayerEntity player) {
         super(ScreenHandlerType.GENERIC_9X6, player, true);
         this.setTitle(new TranslatableText("text.plasmid.ui.game_join.title"));
-        this.updateGames();
+        this.updateUi();
+    }
+
+    private static void tryJoinGame(ServerPlayerEntity player, GameSpace gameSpace) {
+        player.server.submit(() -> {
+            var results = GamePlayerJoiner.tryJoin(player, gameSpace);
+            results.sendErrorsTo(player);
+        });
     }
 
     @Override
@@ -30,27 +45,77 @@ public class GameJoinUi extends SimpleGui {
         super.onTick();
         this.tick++;
         if (this.tick % 20 == 0) {
-            this.updateGames();
+            this.updateUi();
         }
     }
 
-    private void updateGames() {
+    private void updateUi() {
         int i = 0;
+        int gameI = 0;
 
         var games = new ArrayList<>(GameSpaceManager.get().getOpenGameSpaces());
         games.sort(Comparator.comparingInt(space -> space.getPlayers().size()));
 
-        for (ManagedGameSpace gameSpace : games) {
-            if (this.getFirstEmptySlot() != -1) {
-                this.setSlot(i++, this.createIconFor(gameSpace));
+        if (games.size() != 0) {
+            for (int x = 0; x < 183; x++) {
+                games.add(games.get(0));
             }
         }
 
-        for (; i < this.getSize(); i++) {
+        int limit = this.size;
+        this.pageSize = 0;
+
+        if (games.size() > this.size) {
+            limit = NAVBAR_POS;
+            this.pageSize = games.size() / NAVBAR_POS;
+        }
+
+        this.page = MathHelper.clamp(this.page, 0, this.pageSize);
+
+        for (ManagedGameSpace gameSpace : games) {
+            if (gameI >= this.page * NAVBAR_POS) {
+                if (i < limit) {
+                    this.setSlot(i++, this.createIconFor(gameSpace));
+                }
+            }
+            gameI++;
+        }
+
+        for (; i < limit; i++) {
             this.clearSlot(i);
+        }
+
+        if (this.pageSize != 0) {
+            boolean hasPrevious = this.page != 0;
+            boolean hasNext = this.page < this.pageSize;
+
+            this.setSlot(NAVBAR_POS, EMPTY);
+            this.setSlot(NAVBAR_POS + 1, EMPTY);
+
+            this.setSlot(NAVBAR_POS + 2, new GuiElementBuilder(hasPrevious ? Items.LIME_STAINED_GLASS_PANE : Items.BLACK_STAINED_GLASS_PANE)
+                    .setName(new TranslatableText("spectatorMenu.previous_page").formatted(hasPrevious ? Formatting.GOLD : Formatting.DARK_GRAY))
+                    .setCallback((x, y, z) -> this.changePage(-1))
+            );
+            int pageValue = this.page + 1;
+
+            this.setSlot(NAVBAR_POS + 3, Guis.getNumericBanner(pageValue / 100));
+            this.setSlot(NAVBAR_POS + 4, Guis.getNumericBanner(pageValue / 10));
+            this.setSlot(NAVBAR_POS + 5, Guis.getNumericBanner(pageValue));
+
+            this.setSlot(NAVBAR_POS + 6, new GuiElementBuilder(hasNext ? Items.LIME_STAINED_GLASS_PANE : Items.BLACK_STAINED_GLASS_PANE)
+                    .setName(new TranslatableText("spectatorMenu.next_page").formatted(hasNext ? Formatting.GOLD : Formatting.DARK_GRAY))
+                    .setCallback((x, y, z) -> this.changePage(1))
+            );
+
+            this.setSlot(NAVBAR_POS + 7, EMPTY);
+            this.setSlot(NAVBAR_POS + 8, EMPTY);
         }
     }
 
+    private void changePage(int change) {
+        this.page = MathHelper.clamp(this.page + change, 0, this.pageSize);
+        this.updateUi();
+    }
 
     private GuiElementBuilder createIconFor(GameSpace gameSpace) {
         var sourceConfig = gameSpace.getMetadata().sourceConfig();
@@ -76,12 +141,5 @@ public class GameJoinUi extends SimpleGui {
         element.setCallback((a, b, c, d) -> tryJoinGame(this.getPlayer(), gameSpace));
 
         return element;
-    }
-
-    private static void tryJoinGame(ServerPlayerEntity player, GameSpace gameSpace) {
-        player.server.submit(() -> {
-            var results = GamePlayerJoiner.tryJoin(player, gameSpace);
-            results.sendErrorsTo(player);
-        });
     }
 }

--- a/src/main/java/xyz/nucleoid/plasmid/game/config/GameConfig.java
+++ b/src/main/java/xyz/nucleoid/plasmid/game/config/GameConfig.java
@@ -197,7 +197,7 @@ public record GameConfig<C>(
                     PlasmidCodecs.TEXT.optionalFieldOf("short_name").forGetter(Metadata::shortName),
                     MoreCodecs.listOrUnit(PlasmidCodecs.TEXT).optionalFieldOf("description").forGetter(Metadata::description),
                     MoreCodecs.ITEM_STACK.optionalFieldOf("icon", new ItemStack(Items.GRASS_BLOCK)).forGetter(Metadata::icon),
-                    CustomValuesConfig.CODEC.fieldOf("name").orElseGet(CustomValuesConfig::empty).forGetter(Metadata::custom)
+                    CustomValuesConfig.CODEC.fieldOf("custom").orElseGet(CustomValuesConfig::empty).forGetter(Metadata::custom)
             ).apply(instance, Metadata::new);
         });
     }

--- a/src/main/java/xyz/nucleoid/plasmid/game/portal/menu/MenuPortalBackend.java
+++ b/src/main/java/xyz/nucleoid/plasmid/game/portal/menu/MenuPortalBackend.java
@@ -3,25 +3,39 @@ package xyz.nucleoid.plasmid.game.portal.menu;
 import eu.pb4.sgui.api.elements.GuiElementBuilder;
 import eu.pb4.sgui.api.elements.GuiElementInterface;
 import net.minecraft.item.ItemStack;
+import net.minecraft.item.Items;
 import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.text.LiteralText;
+import net.minecraft.text.MutableText;
 import net.minecraft.text.Text;
+import net.minecraft.text.TranslatableText;
 import net.minecraft.util.Formatting;
 import xyz.nucleoid.plasmid.game.GameSpace;
+import xyz.nucleoid.plasmid.game.config.GameConfigs;
 import xyz.nucleoid.plasmid.game.portal.GamePortalBackend;
 import xyz.nucleoid.plasmid.game.portal.GamePortalDisplay;
 import xyz.nucleoid.plasmid.game.portal.on_demand.OnDemandGame;
 import xyz.nucleoid.plasmid.util.Guis;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
 public final class MenuPortalBackend implements GamePortalBackend {
     private final Text name;
     private final List<GameEntry> games;
+    private final MutableText hologramName;
 
     MenuPortalBackend(Text name, List<MenuPortalConfig.Entry> games) {
-        this.name = name.shallowCopy().formatted(Formatting.AQUA);
+        this.name = name;
+        var hologramName = name.shallowCopy();
+
+        if (hologramName.getStyle().getColor() == null) {
+            hologramName.setStyle(hologramName.getStyle().withColor(Formatting.AQUA));
+        }
+
+        this.hologramName = hologramName;
         this.games = this.buildGames(games);
     }
 
@@ -29,7 +43,23 @@ public final class MenuPortalBackend implements GamePortalBackend {
         var games = new ArrayList<GameEntry>(configs.size());
         for (var configEntry : configs) {
             var game = new OnDemandGame(configEntry.game());
-            games.add(new GameEntry(game, configEntry.icon()));
+            var gameConfig = GameConfigs.get(configEntry.game());
+
+            if (gameConfig != null) {
+                games.add(new GameEntry(
+                        game,
+                        configEntry.name().orElse(gameConfig.name()),
+                        configEntry.description().orElse(gameConfig.description()),
+                        configEntry.icon().orElse(gameConfig.icon())
+                ));
+            } else {
+                games.add(new GameEntry(
+                        game,
+                        game.getName(),
+                        Collections.singletonList(new TranslatableText("text.plasmid.game.not_found")),
+                        Items.BARRIER.getDefaultStack()
+                ));
+            }
         }
 
         return games;
@@ -37,7 +67,7 @@ public final class MenuPortalBackend implements GamePortalBackend {
 
     @Override
     public void populateDisplay(GamePortalDisplay display) {
-        display.set(GamePortalDisplay.NAME, this.name);
+        display.set(GamePortalDisplay.NAME, this.hologramName);
 
         int count = 0;
         for (var entry : this.games) {
@@ -54,27 +84,49 @@ public final class MenuPortalBackend implements GamePortalBackend {
         List<GuiElementInterface> games = new ArrayList<>();
 
         for (var entry : this.games) {
-            var uiEntry = GuiElementBuilder.from(entry.icon)
-                    .setName(entry.game.getName().shallowCopy())
-                    .setCallback((x, y, z) -> entry.game.getOrOpen(player.server).handle((gameSpace, throwable) -> {
-                        if (throwable == null) {
-                            future.complete(gameSpace);
-                        } else {
-                            future.completeExceptionally(throwable);
-                        }
-                        return null;
-                    }))
-                    .build();
-
+            var uiEntry = this.createIconFor(entry, future).build();
             games.add(uiEntry);
         }
 
-        var ui = Guis.createSelectorGui(player, this.name.shallowCopy(), games);
+        var ui = Guis.createSelectorGui(player, this.name.shallowCopy(), true, games);
         ui.open();
 
         return future;
     }
 
-    record GameEntry(OnDemandGame game, ItemStack icon) {
+    private GuiElementBuilder createIconFor(GameEntry entry, CompletableFuture<GameSpace> future) {
+            var element = GuiElementBuilder.from(entry.icon().copy())
+                .setName(entry.name().shallowCopy());
+
+        for (var line : entry.description()) {
+            var text = line.shallowCopy();
+
+            if (line.getStyle().getColor() == null) {
+                text.setStyle(line.getStyle().withColor(Formatting.GRAY));
+            }
+
+            element.addLoreLine(text);
+        }
+
+        element.addLoreLine(LiteralText.EMPTY);
+        element.addLoreLine(new LiteralText("")
+                .append(new LiteralText("» ").formatted(Formatting.DARK_GRAY))
+                .append(new TranslatableText("text.plasmid.ui.game_join.players",
+                        new LiteralText(entry.game.getPlayerCount() + "").formatted(Formatting.YELLOW)).formatted(Formatting.GOLD))
+        );
+
+        element.setCallback((a, b, c, gui) -> entry.game.getOrOpen(gui.getPlayer().getServer()).handle((gameSpace, throwable) -> {
+            if (throwable == null) {
+                future.complete(gameSpace);
+            } else {
+                future.completeExceptionally(throwable);
+            }
+            return null;
+        }));
+
+        return element;
+    }
+
+    record GameEntry(OnDemandGame game, Text name, List<Text> description, ItemStack icon) {
     }
 }

--- a/src/main/java/xyz/nucleoid/plasmid/game/portal/menu/MenuPortalConfig.java
+++ b/src/main/java/xyz/nucleoid/plasmid/game/portal/menu/MenuPortalConfig.java
@@ -1,44 +1,48 @@
 package xyz.nucleoid.plasmid.game.portal.menu;
 
+import com.mojang.datafixers.util.Either;
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
-import net.minecraft.block.Blocks;
 import net.minecraft.item.ItemStack;
+import net.minecraft.item.Items;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.text.LiteralText;
 import net.minecraft.text.Text;
-import net.minecraft.text.TranslatableText;
 import net.minecraft.util.Identifier;
 import xyz.nucleoid.codecs.MoreCodecs;
 import xyz.nucleoid.plasmid.game.config.CustomValuesConfig;
 import xyz.nucleoid.plasmid.game.portal.GamePortalBackend;
 import xyz.nucleoid.plasmid.game.portal.GamePortalConfig;
+import xyz.nucleoid.plasmid.util.PlasmidCodecs;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.function.Function;
 
 public record MenuPortalConfig(
-        String translation,
+        Text name,
+        List<Text> description,
+        ItemStack icon,
         List<Entry> games,
         CustomValuesConfig custom
 ) implements GamePortalConfig {
+
     public static final Codec<MenuPortalConfig> CODEC = RecordCodecBuilder.create(instance -> {
         return instance.group(
-                Codec.STRING.optionalFieldOf("translation").forGetter(config -> Optional.ofNullable(config.translation)),
+                PlasmidCodecs.TEXT.optionalFieldOf("name", LiteralText.EMPTY).forGetter(MenuPortalConfig::name),
+                MoreCodecs.listOrUnit(PlasmidCodecs.TEXT).optionalFieldOf("description", Collections.emptyList()).forGetter(MenuPortalConfig::description),
+                MoreCodecs.ITEM_STACK.optionalFieldOf("icon", new ItemStack(Items.GRASS_BLOCK)).forGetter(MenuPortalConfig::icon),
                 Entry.CODEC.listOf().fieldOf("games").forGetter(config -> config.games),
                 CustomValuesConfig.CODEC.optionalFieldOf("custom", CustomValuesConfig.empty()).forGetter(config -> config.custom)
         ).apply(instance, MenuPortalConfig::new);
     });
 
-    private MenuPortalConfig(Optional<String> translation, List<Entry> games, CustomValuesConfig custom) {
-        this(translation.orElse(null), games, custom);
-    }
-
     @Override
     public GamePortalBackend createBackend(MinecraftServer server, Identifier id) {
         Text name;
-        if (this.translation != null) {
-            name = new TranslatableText(this.translation);
+        if (this.name != null) {
+            name = this.name;
         } else {
             name = new LiteralText(id.toString());
         }
@@ -51,12 +55,21 @@ public record MenuPortalConfig(
         return CODEC;
     }
 
-    public record Entry(Identifier game, ItemStack icon) {
-        public static final Codec<Entry> CODEC = RecordCodecBuilder.create(instance -> {
+    public record Entry(Identifier game,
+                        Optional<Text> name,
+                        Optional<List<Text>> description,
+                        Optional<ItemStack> icon) {
+
+        static final Codec<Entry> CODEC_OBJECT = RecordCodecBuilder.create(instance -> {
             return instance.group(
                     Identifier.CODEC.fieldOf("game").forGetter(entry -> entry.game),
-                    MoreCodecs.ITEM_STACK.optionalFieldOf("icon", new ItemStack(Blocks.WHITE_WOOL)).forGetter(entry -> entry.icon)
+                    PlasmidCodecs.TEXT.optionalFieldOf("name").forGetter(Entry::name),
+                    MoreCodecs.listOrUnit(PlasmidCodecs.TEXT).optionalFieldOf("description").forGetter(Entry::description),
+                    MoreCodecs.ITEM_STACK.optionalFieldOf("icon").forGetter(Entry::icon)
             ).apply(instance, Entry::new);
         });
+
+        public static final Codec<Entry> CODEC = Codec.either(Identifier.CODEC, CODEC_OBJECT)
+                .xmap(either -> either.map((identifier) -> new Entry(identifier, Optional.empty(), Optional.empty(), Optional.empty()), Function.identity()), Either::right);
     }
 }

--- a/src/main/java/xyz/nucleoid/plasmid/util/Guis.java
+++ b/src/main/java/xyz/nucleoid/plasmid/util/Guis.java
@@ -4,22 +4,53 @@ import eu.pb4.sgui.api.SlotHolder;
 import eu.pb4.sgui.api.elements.GuiElementInterface;
 import eu.pb4.sgui.api.gui.SimpleGui;
 import eu.pb4.sgui.api.gui.layered.Layer;
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.Items;
+import net.minecraft.nbt.StringNbtReader;
 import net.minecraft.screen.ScreenHandlerType;
 import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.text.LiteralText;
 import net.minecraft.text.MutableText;
 import net.minecraft.util.math.MathHelper;
+import org.jetbrains.annotations.Range;
 
 import java.util.Collection;
 
 public final class Guis {
-    private Guis() {}
+    private static final ItemStack[] NUMBERS = new ItemStack[] {
+            createBanner("{BlockEntityTag:{Patterns:[{Pattern:bs,Color:0},{Pattern:ls,Color:0},{Pattern:ts,Color:0},{Pattern:rs,Color:0},{Pattern:bo,Color:7}]}}"),
+            createBanner("{BlockEntityTag:{Patterns:[{Pattern:cs,Color:0},{Pattern:tl,Color:0},{Pattern:cbo,Color:7},{Pattern:bs,Color:0},{Pattern:bo,Color:7}]}}"),
+            createBanner("{BlockEntityTag:{Patterns:[{Pattern:ts,Color:0},{Pattern:mr,Color:7},{Pattern:bs,Color:0},{Pattern:dls,Color:0},{Pattern:bo,Color:7}]}}"),
+            createBanner("{BlockEntityTag:{Patterns:[{Pattern:bs,Color:0},{Pattern:ms,Color:0},{Pattern:ts,Color:0},{Pattern:cbo,Color:7},{Pattern:rs,Color:0},{Pattern:bo,Color:7}]}}"),
+            createBanner("{BlockEntityTag:{Patterns:[{Pattern:ls,Color:0},{Pattern:hhb,Color:7},{Pattern:rs,Color:0},{Pattern:ms,Color:0},{Pattern:bo,Color:7}]}}"),
+            createBanner("{BlockEntityTag:{Patterns:[{Pattern:bs,Color:0},{Pattern:mr,Color:7},{Pattern:ts,Color:0},{Pattern:drs,Color:0},{Pattern:bo,Color:7}]}}"),
+            createBanner("{BlockEntityTag:{Patterns:[{Pattern:bs,Color:0},{Pattern:rs,Color:0},{Pattern:hh,Color:7},{Pattern:ms,Color:0},{Pattern:ts,Color:0},{Pattern:ls,Color:0},{Pattern:bo,Color:7}]}}"),
+            createBanner("{BlockEntityTag:{Patterns:[{Pattern:dls,Color:0},{Pattern:ts,Color:0},{Pattern:bo,Color:7}]}}"),
+            createBanner("{BlockEntityTag:{Patterns:[{Pattern:dls,Color:0},{Pattern:ts,Color:0},{Pattern:bo,Color:7}]}}"),
+            createBanner("{BlockEntityTag:{Patterns:[{Pattern:ls,Color:0},{Pattern:hhb,Color:7},{Pattern:ms,Color:0},{Pattern:ts,Color:0},{Pattern:rs,Color:0},{Pattern:bs,Color:0},{Pattern:bo,Color:7}]}}")
+    };
 
-    public static SimpleGui createSelectorGui(ServerPlayerEntity player, MutableText text, GuiElementInterface... elements) {
-        var gui = new SimpleGui(selectScreenType(elements.length), player, false);
+    private Guis() {
+    }
+
+    public static SimpleGui createSelectorGui(ServerPlayerEntity player, MutableText text, boolean includePlayerSlots, GuiElementInterface... elements) {
+        var gui = new SimpleGui(selectScreenType(elements.length), player, includePlayerSlots);
         gui.setTitle(text);
 
         buildSelector(gui, elements);
         return gui;
+    }
+
+    public static SimpleGui createSelectorGui(ServerPlayerEntity player, MutableText text, GuiElementInterface... elements) {
+        return createSelectorGui(player, text, false, elements);
+    }
+
+    public static SimpleGui createSelectorGui(ServerPlayerEntity player, MutableText text, Collection<GuiElementInterface> elements) {
+        return createSelectorGui(player, text, false, elements);
+    }
+
+    public static SimpleGui createSelectorGui(ServerPlayerEntity player, MutableText text, boolean includePlayerSlots, Collection<GuiElementInterface> elements) {
+        return createSelectorGui(player, text, includePlayerSlots, elements.toArray(new GuiElementInterface[0]));
     }
 
     public static Layer createSelectorLayer(int height, int width, Collection<GuiElementInterface> elements) {
@@ -30,10 +61,6 @@ public final class Guis {
         var gui = new Layer(height, width);
         buildSelector(gui, elements);
         return gui;
-    }
-
-    public static SimpleGui createSelectorGui(ServerPlayerEntity player, MutableText text, Collection<GuiElementInterface> elements) {
-        return createSelectorGui(player, text, elements.toArray(new GuiElementInterface[0]));
     }
 
     private static void buildSelector(SlotHolder holder, GuiElementInterface... elements) {
@@ -51,6 +78,10 @@ public final class Guis {
         }
     }
 
+    public static ItemStack getNumericBanner(@Range(from = 0, to = 9) int value) {
+        return NUMBERS[Math.abs(value) % 10];
+    }
+
     private static ScreenHandlerType<?> selectScreenType(int rowCount) {
         return switch (MathHelper.ceil(((float) rowCount) / 9)) {
             case 1 -> ScreenHandlerType.GENERIC_9X1;
@@ -60,5 +91,16 @@ public final class Guis {
             case 5 -> ScreenHandlerType.GENERIC_9X5;
             default -> ScreenHandlerType.GENERIC_9X6;
         };
+    }
+
+    private static ItemStack createBanner(String nbt) {
+        ItemStack stack = Items.GRAY_BANNER.getDefaultStack();
+        try {
+            stack.setTag(StringNbtReader.parse(nbt));
+            stack.setCustomName(LiteralText.EMPTY);
+            stack.addHideFlag(ItemStack.TooltipSection.ADDITIONAL);
+        } catch (Exception e) {}
+
+        return stack;
     }
 }


### PR DESCRIPTION
* Updated MenuPortalConfig/Backend to match changes and functionality of GameConfig.
* You can now override name, icon and description of games in portal menus (by default these are pulled directly from GameConfig),
* You can also add entries to it by only providing string/id
* Updated MenuPortalConfig fields to match these in gameConfig (unused for now, but I have plans with them in future).
* Added paging support to /game join ui
* Fixed custom data in GameConfig codec pointing to wrong field