### PR TITLE
Make methods in GameLogic consistent with GameActivity

### DIFF
--- a/src/main/java/xyz/nucleoid/plasmid/game/GameLogic.java
+++ b/src/main/java/xyz/nucleoid/plasmid/game/GameLogic.java
@@ -42,6 +42,28 @@ public final class GameLogic {
     }
 
     /**
+     * Sets a global rule on this {@link GameLogic} to {@link RuleResult#ALLOW}.
+     *
+     * @param rule the rule type
+     * @return the updated {@link GameLogic}
+     * @see GameLogic#setRule(GameRule, RuleResult)
+     */
+    public GameLogic allow(GameRule rule) {
+        return this.setRule(rule, RuleResult.ALLOW);
+    }
+
+    /**
+     * Sets a global rule on this {@link GameLogic} to {@link RuleResult#DENY}.
+     *
+     * @param rule the rule type
+     * @return the updated {@link GameLogic}
+     * @see GameLogic#setRule(GameRule, RuleResult)
+     */
+    public GameLogic deny(GameRule rule) {
+        return this.setRule(rule, RuleResult.DENY);
+    }
+
+    /**
      * Attaches a listener for the given event to this {@link GameLogic}
      *
      * @param event the event type to listen for


### PR DESCRIPTION
This pull request backports Plasmid 0.5's GameActivity methods to Plasmid 0.4's GameLogic. Methods that were removed in Plasmid 0.5 were deprecated rather than removed.