### PR TITLE
Add an empty statistic bundle implementation

### DIFF
--- a/src/main/java/xyz/nucleoid/plasmid/game/GameSpaceStatistics.java
+++ b/src/main/java/xyz/nucleoid/plasmid/game/GameSpaceStatistics.java
@@ -6,6 +6,8 @@ import xyz.nucleoid.plasmid.game.stats.GameStatisticBundle;
 
 import java.util.function.BiConsumer;
 
+import org.jetbrains.annotations.Nullable;
+
 /**
  * Holds the {@link GameStatisticBundle} instances associated with a {@link GameSpace} instance.
  */
@@ -21,6 +23,17 @@ public final class GameSpaceStatistics {
     public GameStatisticBundle bundle(String namespace) {
         GameStatisticBundle.validateNamespace(namespace); // Will throw an exception if validation fails.
         return this.statistics.computeIfAbsent(namespace, $ -> new GameStatisticBundle());
+    }
+
+    /**
+     * Note: bundle namespaces can only contain the characters a-zA-Z0-9_
+     *
+     * @param namespace The statistic namespace to get a bundle for, or {@code null} for an empty bundle
+     * @return the {@link GameStatisticBundle} for the given namespace, or {@linkplain GameStatisticBundle#EMPTY an empty bundle}
+     * @see GameStatisticBundle#bundle(String)
+     */
+    public GameStatisticBundle bundleOrEmpty(@Nullable String namespace) {
+        return namespace == null ? GameStatisticBundle.EMPTY : this.bundle(namespace);
     }
 
     /**

--- a/src/main/java/xyz/nucleoid/plasmid/game/stats/GameStatisticBundle.java
+++ b/src/main/java/xyz/nucleoid/plasmid/game/stats/GameStatisticBundle.java
@@ -15,6 +15,23 @@ import java.util.UUID;
  * key for their namespace in the form <code>statistic.bundle.[namespace]</code>
  */
 public class GameStatisticBundle {
+    public static final GameStatisticBundle EMPTY = new GameStatisticBundle() {
+        @Override
+        public StatisticMap forPlayer(UUID uuid) {
+            return StatisticMap.EMPTY;
+        }
+
+        @Override
+        public StatisticMap global() {
+            return StatisticMap.EMPTY;
+        }
+
+        @Override
+        public boolean isEmpty() {
+            return true;
+        }
+    };
+
     private final Object2ObjectMap<UUID, StatisticMap> players = new Object2ObjectOpenHashMap<>();
     private final StatisticMap global = new StatisticMap();
 

--- a/src/main/java/xyz/nucleoid/plasmid/game/stats/StatisticMap.java
+++ b/src/main/java/xyz/nucleoid/plasmid/game/stats/StatisticMap.java
@@ -10,6 +10,48 @@ import java.util.function.BiConsumer;
  * Stores a mapping of {@link StatisticKey} to their corresponding values
  */
 public class StatisticMap {
+    protected static final StatisticMap EMPTY = new StatisticMap() {
+        @Override
+        public void increment(StatisticKey<Double> key, double amount) {
+            return;
+        }
+
+        @Override
+        public void increment(StatisticKey<Float> key, float amount) {
+            return;
+        }
+
+        @Override
+        public void increment(StatisticKey<Integer> key, int amount) {
+            return;
+        }
+
+        @Override
+        public <T extends Number> T get(StatisticKey<T> key, T defaultValue) {
+            return defaultValue;
+        }
+
+        @Override
+        public void set(StatisticKey<Double> key, double value) {
+            return;
+        }
+
+        @Override
+        public void set(StatisticKey<Float> key, float value) {
+            return;
+        }
+
+        @Override
+        public void set(StatisticKey<Integer> key, int value) {
+            return;
+        }
+
+        @Override
+        public boolean isEmpty() {
+            return true;
+        }
+    };
+
     private final Object2ObjectMap<StatisticKey<?>, Number> values = new Object2ObjectOpenHashMap<>();
 
     public void increment(StatisticKey<Double> key, double amount) {


### PR DESCRIPTION
Empty statistic bundles can be used to safely handle a game configuration that does not specify a bundle namespace without `null`-checking each time the statistics bundle is accessed. This can be accomplished through the added `bundleOrEmpty` method.