### PR TITLE
Better resource pack handling tweaks

### DIFF
--- a/src/main/java/xyz/nucleoid/plasmid/Plasmid.java
+++ b/src/main/java/xyz/nucleoid/plasmid/Plasmid.java
@@ -91,9 +91,9 @@ public final class Plasmid implements ModInitializer {
         ServerLifecycleEvents.SERVER_STARTING.register(server -> {
             GameSpaceManager.openServer(server);
             GamePortalManager.INSTANCE.setup(server);
-            if (PlasmidConfig.get().webServerConfig().enabled()) {
-                httpServer = PlasmidWebServer.start(server);
-            }
+            PlasmidConfig.get().webServerConfig().ifPresent(config -> {
+                httpServer = PlasmidWebServer.start(server, config);
+            });
         });
 
         ServerLifecycleEvents.SERVER_STOPPING.register(server -> {

--- a/src/main/java/xyz/nucleoid/plasmid/PlasmidConfig.java
+++ b/src/main/java/xyz/nucleoid/plasmid/PlasmidConfig.java
@@ -10,17 +10,17 @@ import com.mojang.serialization.codecs.RecordCodecBuilder;
 import org.apache.commons.io.IOUtils;
 import org.jetbrains.annotations.NotNull;
 
-
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Optional;
 
 public record PlasmidConfig(
-        String userFacingPackAddress,
-        PlasmidWebServer.Config webServerConfig
+        Optional<String> userFacingPackAddress,
+        Optional<PlasmidWebServer.Config> webServerConfig
 ) {
     private static final Path PATH = Paths.get("config/plasmid.json");
 
@@ -28,15 +28,18 @@ public record PlasmidConfig(
 
     private static final Codec<PlasmidConfig> CODEC = RecordCodecBuilder.create(instance ->
         instance.group(
-                Codec.STRING.optionalFieldOf("resource_pack_address", "http://127.0.0.1:25566").forGetter(PlasmidConfig::userFacingPackAddress),
-                PlasmidWebServer.Config.CODEC.optionalFieldOf("webserver", PlasmidWebServer.Config.createDefault()).forGetter(PlasmidConfig::webServerConfig)
+                Codec.STRING.optionalFieldOf("resource_pack_address").forGetter(PlasmidConfig::userFacingPackAddress),
+                PlasmidWebServer.Config.CODEC.optionalFieldOf("webserver").forGetter(PlasmidConfig::webServerConfig)
         ).apply(instance, PlasmidConfig::new)
     );
 
     private static PlasmidConfig instance;
 
     private PlasmidConfig() {
-        this("http://127.0.0.1:25566", PlasmidWebServer.Config.createDefault());
+        this(
+                Optional.of("http://127.0.0.1:25566/" + PlasmidWebServer.RESOURCE_PACKS_ENDPOINT),
+                Optional.of(new PlasmidWebServer.Config(25566))
+        );
     }
 
     @NotNull

--- a/src/main/java/xyz/nucleoid/plasmid/PlasmidWebServer.java
+++ b/src/main/java/xyz/nucleoid/plasmid/PlasmidWebServer.java
@@ -1,42 +1,34 @@
 package xyz.nucleoid.plasmid;
 
-import com.google.common.io.Files;
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
 import com.sun.net.httpserver.HttpExchange;
 import com.sun.net.httpserver.HttpHandler;
 import com.sun.net.httpserver.HttpServer;
-import net.fabricmc.loader.api.FabricLoader;
+import joptsimple.internal.Strings;
 import net.minecraft.server.MinecraftServer;
+import org.apache.commons.io.IOUtils;
+import org.apache.http.HttpStatus;
 import org.jetbrains.annotations.Nullable;
-import xyz.nucleoid.plasmid.game.common.GameResourcePack;
+import xyz.nucleoid.plasmid.game.resource_packs.GameResourcePackManager;
 
-import java.io.File;
 import java.io.IOException;
-import java.net.InetAddress;
 import java.net.InetSocketAddress;
-import java.nio.file.Path;
-import java.util.Objects;
 import java.util.concurrent.Executors;
 
-public class PlasmidWebServer implements HttpHandler {
-    private static final Path BASE_PATH = FabricLoader.getInstance().getGameDir().resolve("plasmid-generated");
+public class PlasmidWebServer {
+    public static final String RESOURCE_PACKS_ENDPOINT = "resource-packs";
 
     @Nullable
-    public static HttpServer start(MinecraftServer minecraftServer) {
+    public static HttpServer start(MinecraftServer minecraftServer, Config config) {
         try {
-            var config = PlasmidConfig.get();
-            String serverIp = minecraftServer.getServerIp();
-            if (serverIp == null || serverIp.isEmpty()) {
-                serverIp = InetAddress.getLocalHost().getHostAddress();
-            }
-            var address = new InetSocketAddress(serverIp, config.webServerConfig().serverPort());
+            var address = createBindAddress(minecraftServer, config);
             var server = HttpServer.create(address, 0);
-            server.createContext("/", new PlasmidWebServer());
+            server.createContext("/" + RESOURCE_PACKS_ENDPOINT, new ResourcePacksHandler(RESOURCE_PACKS_ENDPOINT));
             server.setExecutor(Executors.newFixedThreadPool(2));
             server.start();
 
-            Plasmid.LOGGER.info("Web server started at: " + new InetSocketAddress(serverIp, config.webServerConfig().serverPort()));
+            Plasmid.LOGGER.info("Web server started at: " + address);
             return server;
         } catch (IOException e) {
             Plasmid.LOGGER.error("Failed to start the web server!", e);
@@ -45,43 +37,61 @@ public class PlasmidWebServer implements HttpHandler {
         }
     }
 
-    @Override
-    public void handle(HttpExchange exchange) throws IOException {
-        if (Objects.equals(exchange.getRequestMethod(), "GET")) {
-            File file = BASE_PATH.resolve(exchange.getRequestURI().normalize().getPath().substring(1).replace("../", "")).toFile();
+    private static InetSocketAddress createBindAddress(MinecraftServer server, Config config) {
+        var serverIp = server.getServerIp();
+        if (!Strings.isNullOrEmpty(serverIp)) {
+            return new InetSocketAddress(serverIp, config.port());
+        } else {
+            return new InetSocketAddress(config.port());
+        }
+    }
 
-            if (file.exists()) {
-                var outputStream = exchange.getResponseBody();
-
-                exchange.getResponseHeaders().add("User-Agent", "Server: plasmid");
-                exchange.sendResponseHeaders(200, file.length());
-
-                Files.copy(file, outputStream);
-
-                outputStream.flush();
-                outputStream.close();
-                exchange.close();
-                return;
+    private record ResourcePacksHandler(String endpoint) implements HttpHandler {
+        @Override
+        public void handle(HttpExchange exchange) throws IOException {
+            try (exchange) {
+                var resourcePacks = GameResourcePackManager.get();
+                if (resourcePacks.isEmpty() || !this.tryHandle(exchange, resourcePacks.get())) {
+                    exchange.sendResponseHeaders(HttpStatus.SC_NOT_FOUND, 0);
+                }
             }
         }
 
-        exchange.sendResponseHeaders(404, 0);
-        exchange.close();
+        private boolean tryHandle(HttpExchange exchange, GameResourcePackManager resourcePacks) throws IOException {
+            if ("GET".equals(exchange.getRequestMethod())) {
+                return this.tryHandleGet(exchange, resourcePacks);
+            }
+            return false;
+        }
+
+        private boolean tryHandleGet(HttpExchange exchange, GameResourcePackManager resourcePacks) throws IOException {
+            var path = exchange.getRequestURI().getPath().substring(this.endpoint.length() + 2);
+            var pack = resourcePacks.load(path);
+            if (pack != null) {
+                try (
+                        var input = pack.openInputStream();
+                        var output = exchange.getResponseBody()
+                ) {
+                    exchange.getResponseHeaders().add("Server", "plasmid");
+                    exchange.getResponseHeaders().add("Content-Type", "application/zip");
+                    exchange.sendResponseHeaders(HttpStatus.SC_OK, pack.getSize());
+
+                    IOUtils.copy(input, output);
+                    output.flush();
+
+                    return true;
+                }
+            }
+
+            return false;
+        }
     }
 
-    public record Config(
-            boolean enabled,
-            int serverPort
-    ) {
-        protected static final Codec<Config> CODEC = RecordCodecBuilder.create(instance ->
+    public record Config(int port) {
+        public static final Codec<Config> CODEC = RecordCodecBuilder.create(instance ->
                 instance.group(
-                        Codec.BOOL.optionalFieldOf("enabled", false).forGetter(Config::enabled),
-                        Codec.INT.optionalFieldOf("port", 25566).forGetter(Config::serverPort)
+                        Codec.INT.fieldOf("port").forGetter(Config::port)
                 ).apply(instance, Config::new)
         );
-
-        public static Config createDefault() {
-            return new Config(false, 25566);
-        }
     }
 }

--- a/src/main/java/xyz/nucleoid/plasmid/PlasmidWebServer.java
+++ b/src/main/java/xyz/nucleoid/plasmid/PlasmidWebServer.java
@@ -1,11 +1,11 @@
 package xyz.nucleoid.plasmid;
 
+import com.google.common.base.Strings;
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
 import com.sun.net.httpserver.HttpExchange;
 import com.sun.net.httpserver.HttpHandler;
 import com.sun.net.httpserver.HttpServer;
-import joptsimple.internal.Strings;
 import net.minecraft.server.MinecraftServer;
 import org.apache.commons.io.IOUtils;
 import org.apache.http.HttpStatus;

--- a/src/main/java/xyz/nucleoid/plasmid/game/GameSpace.java
+++ b/src/main/java/xyz/nucleoid/plasmid/game/GameSpace.java
@@ -7,6 +7,7 @@ import xyz.nucleoid.fantasy.RuntimeWorldConfig;
 import xyz.nucleoid.plasmid.game.event.GameActivityEvents;
 import xyz.nucleoid.plasmid.game.event.GamePlayerEvents;
 import xyz.nucleoid.plasmid.game.player.PlayerSet;
+import xyz.nucleoid.plasmid.game.resource_packs.ResourcePackStates;
 import xyz.nucleoid.plasmid.game.world.GameSpaceWorlds;
 
 import java.util.function.Consumer;

--- a/src/main/java/xyz/nucleoid/plasmid/game/common/GameResourcePack.java
+++ b/src/main/java/xyz/nucleoid/plasmid/game/common/GameResourcePack.java
@@ -1,25 +1,15 @@
 package xyz.nucleoid.plasmid.game.common;
 
-import com.google.common.hash.Hashing;
 import eu.pb4.polymer.api.resourcepack.ResourcePackCreator;
-import net.fabricmc.loader.api.FabricLoader;
-import net.minecraft.SharedConstants;
 import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.text.Text;
-import net.minecraft.util.Identifier;
 import org.jetbrains.annotations.ApiStatus;
 import xyz.nucleoid.plasmid.Plasmid;
-import xyz.nucleoid.plasmid.PlasmidConfig;
 import xyz.nucleoid.plasmid.game.GameActivity;
 import xyz.nucleoid.plasmid.game.event.GamePlayerEvents;
+import xyz.nucleoid.plasmid.game.resource_packs.GameResourcePackManager;
 
-import java.io.File;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.StandardOpenOption;
-import java.util.zip.ZipEntry;
-import java.util.zip.ZipOutputStream;
+import java.util.Optional;
 
 // TODO: prevent resource-pack soft-lock
 
@@ -29,8 +19,6 @@ import java.util.zip.ZipOutputStream;
  * @see GameResourcePack#addTo(GameActivity)
  */
 public final class GameResourcePack {
-    public static final Path BASE_PATH = FabricLoader.getInstance().getGameDir().resolve("plasmid-generated").resolve("resource-packs");
-    public static final GameResourcePack EMPTY;
     private final String url;
     private final String hash;
     private boolean required;
@@ -80,62 +68,14 @@ public final class GameResourcePack {
         player.sendResourcePackUrl(this.url, this.hash, this.required, this.prompt);
     }
 
-    /**
-     * Generates resource pack from Polymer's {@link ResourcePackCreator}
-     * Created GameResourcePack instance should be stored and used for multiple GameActivities
-     *
-     * @param identifier Unique {@link Identifier}
-     * @param creator Polymer {@link ResourcePackCreator}
-     * @return Instance of {@link GameResourcePack}
-     */
-    public static GameResourcePack create(Identifier identifier, ResourcePackCreator creator) {
-        String sha1;
-        try {
-            Files.createDirectories(BASE_PATH);
-            var packPath = BASE_PATH.resolve(identifier.getNamespace()).resolve(identifier.getPath() + ".zip");
-            creator.build(packPath);
-            sha1 = createSha1(packPath.toFile());
-        } catch (Exception e) {
-            Plasmid.LOGGER.error("Couldn't generate resource pack " + identifier.toString(), e);
-            return EMPTY;
-        }
-
-        return new GameResourcePack(PlasmidConfig.get().userFacingPackAddress() + "/resource-packs/" + identifier.getNamespace() + "/" + identifier.getPath() + ".zip?" + sha1, sha1);
-    }
-
-    private static String createSha1(File file) throws Exception {
-        return com.google.common.io.Files.asByteSource(file).hash(Hashing.sha1()).toString();
-    }
-
-    static {
-        GameResourcePack emptyPack;
-
-        try {
-            var path = BASE_PATH.resolve("empty.zip");
-            var outputStream = new ZipOutputStream(Files.newOutputStream(path, StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING));
-
-
-            var entry = new ZipEntry("pack.mcmeta");
-            entry.setTime(0);
-            outputStream.putNextEntry(entry);
-            outputStream.write(("{" +
-                    "   \"pack\":{" +
-                    "      \"pack_format\":" + SharedConstants.RESOURCE_PACK_VERSION + "," +
-                    "      \"description\":\"Empty Resource Pack\"" +
-                    "   }\n" +
-                    "}\n").getBytes(StandardCharsets.UTF_8));
-
-            outputStream.closeEntry();
-            outputStream.close();
-
-            var sha1 = createSha1(path.toFile());
-
-            emptyPack = new GameResourcePack(PlasmidConfig.get().userFacingPackAddress() + "/resource-packs/empty.zip?" + sha1, sha1);
-        } catch (Exception e) {
-            Plasmid.LOGGER.error("Couldn't generate empty resource pack!", e);
-            emptyPack = new GameResourcePack("", "");
-        }
-
-        EMPTY = emptyPack;
+    public static Optional<GameResourcePack> tryRegister(ResourcePackCreator creator) {
+        return GameResourcePackManager.get().flatMap(packs -> {
+            try {
+                return Optional.of(packs.register(creator));
+            } catch (Exception e) {
+                Plasmid.LOGGER.error("Failed to generate resource pack", e);
+                return Optional.empty();
+            }
+        });
     }
 }

--- a/src/main/java/xyz/nucleoid/plasmid/game/manager/ManagedGameSpace.java
+++ b/src/main/java/xyz/nucleoid/plasmid/game/manager/ManagedGameSpace.java
@@ -1,7 +1,6 @@
 package xyz.nucleoid.plasmid.game.manager;
 
 import com.google.common.collect.Lists;
-import eu.pb4.polymer.api.x.BlockMapper;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.text.LiteralText;
@@ -16,6 +15,7 @@ import xyz.nucleoid.plasmid.game.event.GameActivityEvents;
 import xyz.nucleoid.plasmid.game.event.GamePlayerEvents;
 import xyz.nucleoid.plasmid.game.player.PlayerOffer;
 import xyz.nucleoid.plasmid.game.player.PlayerOfferResult;
+import xyz.nucleoid.plasmid.game.resource_packs.ResourcePackStates;
 
 import java.util.Collection;
 import java.util.function.Consumer;

--- a/src/main/java/xyz/nucleoid/plasmid/game/resource_packs/GameResourcePackManager.java
+++ b/src/main/java/xyz/nucleoid/plasmid/game/resource_packs/GameResourcePackManager.java
@@ -1,0 +1,177 @@
+package xyz.nucleoid.plasmid.game.resource_packs;
+
+import com.google.common.hash.Hashing;
+import com.google.gson.JsonObject;
+import eu.pb4.polymer.api.resourcepack.ResourcePackCreator;
+import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
+import net.fabricmc.loader.api.FabricLoader;
+import net.minecraft.SharedConstants;
+import net.minecraft.util.Util;
+import org.jetbrains.annotations.Nullable;
+import xyz.nucleoid.plasmid.Plasmid;
+import xyz.nucleoid.plasmid.PlasmidConfig;
+import xyz.nucleoid.plasmid.game.common.GameResourcePack;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.nio.file.StandardOpenOption;
+import java.util.Map;
+import java.util.Optional;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+
+/**
+ * Manager for all resource packs tracked by the server.
+ *
+ * @see GameResourcePack
+ */
+public final class GameResourcePackManager {
+    private static final Path ROOT = FabricLoader.getInstance().getGameDir()
+            .resolve("plasmid-generated/resource-packs");
+
+    private static final Path TEMPORARY = ROOT.resolve("tmp.zip");
+
+    private static GameResourcePackManager instance;
+
+    private final String packEndpoint;
+
+    private final Map<String, ServedPack> hashToServedPack = new Object2ObjectOpenHashMap<>();
+    private GameResourcePack emptyPack;
+
+    private GameResourcePackManager(String packEndpoint) {
+        this.packEndpoint = packEndpoint;
+    }
+
+    public static Optional<GameResourcePackManager> get() {
+        var instance = GameResourcePackManager.instance;
+        if (instance == null) {
+            var packEndpoint = PlasmidConfig.get().userFacingPackAddress();
+            if (packEndpoint.isPresent()) {
+                GameResourcePackManager.instance = instance = new GameResourcePackManager(packEndpoint.get());
+            }
+        }
+
+        return Optional.ofNullable(instance);
+    }
+
+    public static Optional<GameResourcePack> emptyPack() {
+        return get().flatMap(packs -> {
+            try {
+                return Optional.of(packs.getEmptyPack());
+            } catch (Exception e) {
+                Plasmid.LOGGER.error("Failed to build empty resource pack", e);
+                return Optional.empty();
+            }
+        });
+    }
+
+    @Nullable
+    public GameResourcePackManager.ServedPack load(String query) {
+        var pack = this.hashToServedPack.get(query);
+        if (pack == null) {
+            return null;
+        }
+
+        if (!Files.exists(pack.path)) {
+            this.hashToServedPack.remove(query);
+            return null;
+        }
+
+        return pack;
+    }
+
+    /**
+     * Generates resource pack from Polymer's {@link ResourcePackCreator}
+     * Created GameResourcePack instance should be stored and used for multiple GameActivities
+     *
+     * @param creator Polymer {@link ResourcePackCreator}
+     * @return Instance of {@link GameResourcePack}
+     */
+    public GameResourcePack register(ResourcePackCreator creator) throws Exception {
+        return this.register(creator::build);
+    }
+
+    public GameResourcePack register(Builder builder) throws Exception {
+        Files.createDirectories(ROOT);
+
+        synchronized (TEMPORARY) {
+            Files.deleteIfExists(TEMPORARY);
+            builder.accept(TEMPORARY);
+
+            var hash = hash(TEMPORARY);
+            var path = this.getPathFor(hash);
+
+            Files.move(TEMPORARY, path, StandardCopyOption.REPLACE_EXISTING);
+
+            var pack = new ServedPack(path, Files.size(path));
+            this.hashToServedPack.put(hash, pack);
+
+            return new GameResourcePack(this.getUrlFor(hash), hash);
+        }
+    }
+
+    private String getUrlFor(String hash) {
+        return this.packEndpoint + "/" + hash;
+    }
+
+    public GameResourcePack getEmptyPack() throws Exception {
+        var emptyPack = this.emptyPack;
+        if (emptyPack == null) {
+            this.emptyPack = emptyPack = this.register(this::buildEmptyPack);
+        }
+
+        return emptyPack;
+    }
+
+    private Path getPathFor(String hash) {
+        return ROOT.resolve(hash + ".zip");
+    }
+
+    private void buildEmptyPack(Path path) throws Exception {
+        try (var output = new ZipOutputStream(Files.newOutputStream(path, StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING))) {
+            var json = new JsonObject();
+            json.add("pack", Util.make(() -> {
+                var pack = new JsonObject();
+                pack.addProperty("pack_format", SharedConstants.RESOURCE_PACK_VERSION);
+                pack.addProperty("description", "Empty Resource Pack");
+                return pack;
+            }));
+
+            var entry = new ZipEntry("pack.mcmeta");
+            entry.setTime(0);
+            output.putNextEntry(entry);
+            output.write(json.toString().getBytes(StandardCharsets.UTF_8));
+            output.closeEntry();
+        }
+    }
+
+    private static String hash(Path path) throws IOException {
+        return com.google.common.io.Files.asByteSource(path.toFile()).hash(Hashing.sha1()).toString();
+    }
+
+    public interface Builder {
+        void accept(Path path) throws Exception;
+    }
+
+    public static final class ServedPack {
+        private final Path path;
+        private final long size;
+
+        private ServedPack(Path path, long size) {
+            this.path = path;
+            this.size = size;
+        }
+
+        public InputStream openInputStream() throws IOException {
+            return Files.newInputStream(this.path);
+        }
+
+        public long getSize() {
+            return this.size;
+        }
+    }
+}

--- a/src/testmod/java/xyz/nucleoid/plasmid/test/TestGameWithResourcePack.java
+++ b/src/testmod/java/xyz/nucleoid/plasmid/test/TestGameWithResourcePack.java
@@ -2,7 +2,6 @@ package xyz.nucleoid.plasmid.test;
 
 import eu.pb4.polymer.api.utils.PolymerUtils;
 import eu.pb4.polymer.api.x.BlockMapper;
-import net.minecraft.block.Blocks;
 import net.minecraft.scoreboard.AbstractTeam;
 import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.text.LiteralText;
@@ -88,7 +87,7 @@ public final class TestGameWithResourcePack {
             teamManager.addTeam(TEAM);
 
             if (iter != 3) {
-                TestInitializer.RESOURCE_PACK.addTo(activity);
+                TestInitializer.resourcePack.ifPresent(pack -> pack.addTo(activity));
             }
 
             activity.listen(GamePlayerEvents.ADD, player -> {

--- a/src/testmod/java/xyz/nucleoid/plasmid/test/TestInitializer.java
+++ b/src/testmod/java/xyz/nucleoid/plasmid/test/TestInitializer.java
@@ -17,6 +17,8 @@ import net.minecraft.util.registry.Registry;
 import xyz.nucleoid.plasmid.game.GameType;
 import xyz.nucleoid.plasmid.game.common.GameResourcePack;
 
+import java.util.Optional;
+
 public class TestInitializer implements ModInitializer {
     public static final String ID = "testmod";
     public static final ResourcePackCreator CREATOR = ResourcePackCreator.create();
@@ -33,7 +35,7 @@ public class TestInitializer implements ModInitializer {
             CREATOR.requestModel(Items.NOTE_BLOCK, id("block/chair"))
     );
 
-    public static GameResourcePack RESOURCE_PACK = GameResourcePack.create(id("pack"), CREATOR);
+    public static Optional<GameResourcePack> resourcePack = Optional.empty();
 
     @Override
     public void onInitialize() {
@@ -44,7 +46,7 @@ public class TestInitializer implements ModInitializer {
 
 
         CREATOR.addAssetSource("plasmid-test-mod");
-        RESOURCE_PACK = GameResourcePack.create(id("pack"), CREATOR);
+        resourcePack = GameResourcePack.tryRegister(CREATOR);
     }
 
     private static final Identifier id(String path) {


### PR DESCRIPTION
This mainly directs all resource pack handling through a dedicated manager type, which abstracts access to the filesystem.

Resource pack access is also no longer referenced by an identifier, but rather just its hash.