### PR TITLE
Fix Sign Game Portals Blocking Server Loading

### DIFF
--- a/src/main/java/xyz/nucleoid/plasmid/mixin/game/portal/SignBlockEntityMixin.java
+++ b/src/main/java/xyz/nucleoid/plasmid/mixin/game/portal/SignBlockEntityMixin.java
@@ -55,7 +55,6 @@ public abstract class SignBlockEntityMixin extends BlockEntity implements GamePo
         }
 
         if (this.hasWorld()) {
-            this.markDirty();
             BlockState cachedState = this.getCachedState();
             this.world.updateListeners(this.pos, cachedState, cachedState, Block.NOTIFY_ALL);
         }


### PR DESCRIPTION
Hi,

Unsure if anyone else ran into this problem, but adding a sign portal caused my server to get stuck on "Preparing spawn area" forever when rebooted.
I was able to recreate this on a local and remote server.

I tracked the issue down to a `markDirty` call, which I don't believe is necessary in this case anyway. 
Removing the line fixed the problem with no further issues.