### PR TITLE
Fix waiting lobby sidebars not being initialized with content

### DIFF
--- a/src/main/java/xyz/nucleoid/plasmid/game/common/GameWaitingLobby.java
+++ b/src/main/java/xyz/nucleoid/plasmid/game/common/GameWaitingLobby.java
@@ -105,6 +105,7 @@ public final class GameWaitingLobby {
         }
 
         lobby.sidebar.setTitle(title);
+        lobby.updateSidebar();
         lobby.sidebar.show();
 
         return lobby;
@@ -135,7 +136,7 @@ public final class GameWaitingLobby {
         if (time % 20 == 0) {
             this.updateCountdown();
             this.tickCountdownBar();
-            this.tickSidebar();
+            this.updateSidebar();
             this.tickCountdownSound();
         }
 
@@ -252,7 +253,7 @@ public final class GameWaitingLobby {
         }
     }
 
-    private void tickSidebar() {
+    private void updateSidebar() {
         this.sidebar.set((b) -> {
             b.add(PADDING_LINE);
             if (this.countdownStart != -1) {


### PR DESCRIPTION
The waiting lobby sidebar's content is updated every second based on a `time % 20 == 0` check, but the `time` value starts at 1 for game tick listeners. This pull request changes this behavior to also update the sidebar's content when first constructed, removing the up to one-second delay where the sidebar would appear empty for players upon the creation of the waiting lobby.