### PR TITLE
Add the stop spectating entity rule type

### DIFF
--- a/src/main/java/xyz/nucleoid/plasmid/api/game/rule/GameRuleType.java
+++ b/src/main/java/xyz/nucleoid/plasmid/api/game/rule/GameRuleType.java
@@ -111,6 +111,7 @@ public final class GameRuleType {
             .enforces(CoralDeathEvent.EVENT, result -> (world, pos, from, to) -> result);
 
     public static final GameRuleType DISMOUNT_VEHICLE = GameRuleType.create();
+    public static final GameRuleType STOP_SPECTATING_ENTITY = GameRuleType.create();
     public static final GameRuleType PLAYER_PROJECTILE_KNOCKBACK = GameRuleType.create();
     public static final GameRuleType TRIDENTS_LOYAL_IN_VOID = GameRuleType.create();
     public static final GameRuleType MODIFY_INVENTORY = GameRuleType.create();

--- a/src/main/java/xyz/nucleoid/plasmid/mixin/game/rule/ServerPlayerEntityMixin.java
+++ b/src/main/java/xyz/nucleoid/plasmid/mixin/game/rule/ServerPlayerEntityMixin.java
@@ -1,6 +1,8 @@
 package xyz.nucleoid.plasmid.mixin.game.rule;
 
+import com.llamalad7.mixinextras.injector.v2.WrapWithCondition;
 import com.mojang.authlib.GameProfile;
+import net.minecraft.entity.Entity;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.util.math.BlockPos;
@@ -9,12 +11,30 @@ import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+import xyz.nucleoid.plasmid.api.game.rule.GameRuleType;
 import xyz.nucleoid.plasmid.impl.game.manager.GameSpaceManagerImpl;
+import xyz.nucleoid.stimuli.event.EventResult;
 
 @Mixin(ServerPlayerEntity.class)
 public abstract class ServerPlayerEntityMixin extends PlayerEntity {
     private ServerPlayerEntityMixin(World world, BlockPos pos, float yaw, GameProfile profile) {
         super(world, pos, yaw, profile);
+    }
+
+    @WrapWithCondition(
+            method = "tick",
+            // The targeted call handles shifting to stop spectating
+            // The other call handles dead entities, which should always stop being spectated
+            at = @At(value = "INVOKE", target = "Lnet/minecraft/server/network/ServerPlayerEntity;setCameraEntity(Lnet/minecraft/entity/Entity;)V", ordinal = 0)
+    )
+    private boolean preventStopSpectatingEntity(ServerPlayerEntity player, Entity entity) {
+        var gameSpace = GameSpaceManagerImpl.get().byPlayer(player);
+
+        if (gameSpace != null && gameSpace.getBehavior().testRule(GameRuleType.STOP_SPECTATING_ENTITY) == EventResult.DENY) {
+            return false;
+        }
+
+        return true;
     }
 
     @Inject(method = "isPvpEnabled", at = @At("HEAD"), cancellable = true)

--- a/src/testmod/java/xyz/nucleoid/plasmid/test/TestGame.java
+++ b/src/testmod/java/xyz/nucleoid/plasmid/test/TestGame.java
@@ -6,8 +6,10 @@ import net.minecraft.block.Blocks;
 import net.minecraft.block.ButtonBlock;
 import net.minecraft.block.LeavesBlock;
 import net.minecraft.block.enums.BlockFace;
+import net.minecraft.entity.EntityType;
 import net.minecraft.item.Item;
 import net.minecraft.item.Items;
+import net.minecraft.nbt.NbtCompound;
 import net.minecraft.scoreboard.AbstractTeam;
 import net.minecraft.screen.ScreenTexts;
 import net.minecraft.server.network.ServerPlayerEntity;
@@ -18,11 +20,13 @@ import net.minecraft.util.DyeColor;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.Util;
 import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.Direction;
 import net.minecraft.util.math.Vec3d;
 import net.minecraft.world.GameMode;
 import net.minecraft.world.GameRules;
 import xyz.nucleoid.fantasy.RuntimeWorldConfig;
 import xyz.nucleoid.map_templates.BlockBounds;
+import xyz.nucleoid.map_templates.MapEntity;
 import xyz.nucleoid.map_templates.MapTemplate;
 import xyz.nucleoid.plasmid.api.game.*;
 import xyz.nucleoid.plasmid.api.game.common.team.*;
@@ -152,7 +156,7 @@ public final class TestGame {
             long currentTime = gameSpace.getTime();
             activity.deny(GameRuleType.PVP).allow(GameRuleType.MODIFY_ARMOR);
             activity.deny(GameRuleType.FALL_DAMAGE).deny(GameRuleType.HUNGER);
-            activity.deny(GameRuleType.THROW_ITEMS);
+            activity.deny(GameRuleType.THROW_ITEMS).deny(GameRuleType.STOP_SPECTATING_ENTITY);
 
             activity.deny(GameRuleType.INTERACTION).allow(GameRuleType.USE_BLOCKS);
 
@@ -213,6 +217,13 @@ public final class TestGame {
 
         var edge = new BlockPos(max.getX(), max.getY() + 1, max.getZ());
         template.setBlockState(edge, BUTTON);
+
+        var armorStandNbt = new NbtCompound();
+        armorStandNbt.putString("id", EntityType.getId(EntityType.ARMOR_STAND).toString());
+        armorStandNbt.putBoolean("NoGravity", true);
+
+        var armorStandPos = Vec3d.ofBottomCenter(edge.offset(Direction.WEST));
+        template.addEntity(new MapEntity(armorStandPos, armorStandNbt));
 
         for (var pos : bounds) {
             template.setBlockState(pos, state);


### PR DESCRIPTION
This pull request implements a rule type for players stopping spectating entities, which is useful for restricting the player's actions when the game is controlling the camera.

To use this rule, games can deny it when provided a `GameActivity` instance:

```java
gameSpace.setActivity(activity -> {
            activity.deny(GameRuleType.STOP_SPECTATING_ENTITY);

            // Other game setup
            // ...
});
```