### PR TITLE
Allow groups to be added to team allocators

### DIFF
--- a/src/main/java/xyz/nucleoid/plasmid/api/event/GameEvents.java
+++ b/src/main/java/xyz/nucleoid/plasmid/api/event/GameEvents.java
@@ -4,6 +4,7 @@ import net.fabricmc.fabric.api.event.Event;
 import net.fabricmc.fabric.api.event.EventFactory;
 import net.minecraft.registry.entry.RegistryEntry;
 import net.minecraft.server.network.ServerPlayerEntity;
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Nullable;
 import xyz.nucleoid.plasmid.api.game.GameActivity;
 import xyz.nucleoid.plasmid.api.game.GameCloseReason;
@@ -74,6 +75,7 @@ public final class GameEvents {
         }
     });
 
+    @ApiStatus.Experimental
     public static final Event<TeamSelectionLobbyFinalize> TEAM_SELECTION_LOBBY_FINALIZE = EventFactory.createArrayBacked(TeamSelectionLobbyFinalize.class, listeners -> (gameSpace, allocator, players) -> {
         for (var listener : listeners) {
             listener.onFinalizeTeamSelection(gameSpace, allocator, players);
@@ -153,6 +155,7 @@ public final class GameEvents {
         void onPlayerLeft(GameSpace gameSpace, ServerPlayerEntity player);
     }
 
+    @ApiStatus.Experimental
     public interface TeamSelectionLobbyFinalize {
         /**
          * @param gameSpace The {@link GameSpace} the game is running in.

--- a/src/main/java/xyz/nucleoid/plasmid/api/event/GameEvents.java
+++ b/src/main/java/xyz/nucleoid/plasmid/api/event/GameEvents.java
@@ -9,7 +9,10 @@ import xyz.nucleoid.plasmid.api.game.GameActivity;
 import xyz.nucleoid.plasmid.api.game.GameCloseReason;
 import xyz.nucleoid.plasmid.api.game.GameResult;
 import xyz.nucleoid.plasmid.api.game.GameSpace;
+import xyz.nucleoid.plasmid.api.game.common.team.GameTeamKey;
+import xyz.nucleoid.plasmid.api.game.common.team.TeamAllocator;
 import xyz.nucleoid.plasmid.api.game.config.GameConfig;
+import xyz.nucleoid.plasmid.api.game.player.PlayerIterable;
 
 import java.util.Set;
 
@@ -68,6 +71,12 @@ public final class GameEvents {
     public static final Event<PlayerLeft> PLAYER_LEFT = EventFactory.createArrayBacked(PlayerLeft.class, listeners -> (gameSpace, player) -> {
         for (var listener : listeners) {
             listener.onPlayerLeft(gameSpace, player);
+        }
+    });
+
+    public static final Event<TeamSelectionLobbyFinalize> TEAM_SELECTION_LOBBY_FINALIZE = EventFactory.createArrayBacked(TeamSelectionLobbyFinalize.class, listeners -> (gameSpace, allocator, players) -> {
+        for (var listener : listeners) {
+            listener.onFinalizeTeamSelection(gameSpace, allocator, players);
         }
     });
 
@@ -142,6 +151,15 @@ public final class GameEvents {
          * @param player the initial player who tried to leave a {@link GameSpace}
          */
         void onPlayerLeft(GameSpace gameSpace, ServerPlayerEntity player);
+    }
+
+    public interface TeamSelectionLobbyFinalize {
+        /**
+         * @param gameSpace The {@link GameSpace} the game is running in.
+         * @param allocator the allocator that is handling the team selections
+         * @param players the players that the allocator is handling
+         */
+        void onFinalizeTeamSelection(GameSpace gameSpace, TeamAllocator<GameTeamKey, ServerPlayerEntity> allocator, PlayerIterable players);
     }
 
 }

--- a/src/main/java/xyz/nucleoid/plasmid/api/game/common/team/TeamAllocator.java
+++ b/src/main/java/xyz/nucleoid/plasmid/api/game/common/team/TeamAllocator.java
@@ -7,6 +7,7 @@ import com.google.common.collect.Sets;
 import it.unimi.dsi.fastutil.objects.Object2IntMap;
 import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
 import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.*;
@@ -70,6 +71,7 @@ public final class TeamAllocator<T, V> {
      *
      * @param group the group to add to this allocator
      */
+    @ApiStatus.Experimental
     public void group(Iterable<V> group) {
         for (var player : group) {
             if (!this.players.contains(player)) {

--- a/src/main/java/xyz/nucleoid/plasmid/api/game/common/team/TeamSelectionLobby.java
+++ b/src/main/java/xyz/nucleoid/plasmid/api/game/common/team/TeamSelectionLobby.java
@@ -6,11 +6,13 @@ import it.unimi.dsi.fastutil.objects.Reference2IntMaps;
 import it.unimi.dsi.fastutil.objects.Reference2IntOpenHashMap;
 import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.text.Text;
+import xyz.nucleoid.plasmid.api.event.GameEvents;
 import xyz.nucleoid.plasmid.api.game.GameActivity;
 import xyz.nucleoid.plasmid.api.game.GameSpace;
 import xyz.nucleoid.plasmid.api.game.common.GameWaitingLobby;
 import xyz.nucleoid.plasmid.api.game.common.ui.WaitingLobbyUiLayout;
 import xyz.nucleoid.plasmid.api.game.event.GameWaitingLobbyEvents;
+import xyz.nucleoid.plasmid.api.game.event.TeamSelectionLobbyEvents;
 import xyz.nucleoid.plasmid.api.game.player.PlayerIterable;
 import xyz.nucleoid.plasmid.impl.game.common.ui.element.TeamSelectionWaitingLobbyUiElement;
 
@@ -110,6 +112,9 @@ public final class TeamSelectionLobby {
             GameTeamKey preference = this.teamPreference.get(player.getUuid());
             allocator.add(player, preference);
         }
+
+        this.gameSpace.getBehavior().invoker(TeamSelectionLobbyEvents.FINALIZE).onFinalizeTeamSelection(allocator, players);
+        GameEvents.TEAM_SELECTION_LOBBY_FINALIZE.invoker().onFinalizeTeamSelection(gameSpace, allocator, players);
 
         allocator.allocate(apply);
     }

--- a/src/main/java/xyz/nucleoid/plasmid/api/game/event/TeamSelectionLobbyEvents.java
+++ b/src/main/java/xyz/nucleoid/plasmid/api/game/event/TeamSelectionLobbyEvents.java
@@ -1,0 +1,35 @@
+package xyz.nucleoid.plasmid.api.game.event;
+
+import net.minecraft.server.network.ServerPlayerEntity;
+import xyz.nucleoid.plasmid.api.game.GameActivity;
+import xyz.nucleoid.plasmid.api.game.GameSpace;
+import xyz.nucleoid.plasmid.api.game.common.team.GameTeamKey;
+import xyz.nucleoid.plasmid.api.game.common.team.TeamAllocator;
+import xyz.nucleoid.plasmid.api.game.common.team.TeamSelectionLobby;
+import xyz.nucleoid.plasmid.api.game.player.PlayerIterable;
+import xyz.nucleoid.stimuli.event.StimulusEvent;
+
+/**
+ * Events relating to a {@link TeamSelectionLobby} applied to a {@link GameActivity} within a {@link GameSpace}.
+ */
+public final class TeamSelectionLobbyEvents {
+    /**
+     * Called when a {@link TeamAllocator} has been populated to allocate selected teams for a game.
+     * <p>
+     * This event can be used to replace team preferences or add groups of
+	 * players that should be on the same team.
+     */
+    public static final StimulusEvent<Finalize> FINALIZE = StimulusEvent.create(Finalize.class, ctx -> (allocator, players) -> {
+        try {
+            for (var listener : ctx.getListeners()) {
+                listener.onFinalizeTeamSelection(allocator, players);
+            }
+        } catch (Throwable throwable) {
+            ctx.handleException(throwable);
+        }
+    });
+
+    public interface Finalize {
+        void onFinalizeTeamSelection(TeamAllocator<GameTeamKey, ServerPlayerEntity> allocator, PlayerIterable players);
+    }
+}

--- a/src/main/java/xyz/nucleoid/plasmid/api/game/event/TeamSelectionLobbyEvents.java
+++ b/src/main/java/xyz/nucleoid/plasmid/api/game/event/TeamSelectionLobbyEvents.java
@@ -1,6 +1,7 @@
 package xyz.nucleoid.plasmid.api.game.event;
 
 import net.minecraft.server.network.ServerPlayerEntity;
+import org.jetbrains.annotations.ApiStatus;
 import xyz.nucleoid.plasmid.api.game.GameActivity;
 import xyz.nucleoid.plasmid.api.game.GameSpace;
 import xyz.nucleoid.plasmid.api.game.common.team.GameTeamKey;
@@ -12,6 +13,7 @@ import xyz.nucleoid.stimuli.event.StimulusEvent;
 /**
  * Events relating to a {@link TeamSelectionLobby} applied to a {@link GameActivity} within a {@link GameSpace}.
  */
+@ApiStatus.Experimental
 public final class TeamSelectionLobbyEvents {
     /**
      * Called when a {@link TeamAllocator} has been populated to allocate selected teams for a game.

--- a/src/test/java/xyz/nucleoid/plasmid/test/TeamAllocatorTests.java
+++ b/src/test/java/xyz/nucleoid/plasmid/test/TeamAllocatorTests.java
@@ -1,0 +1,240 @@
+package xyz.nucleoid.plasmid.test;
+
+import com.google.common.collect.ImmutableMultimap;
+import com.google.common.collect.Multimap;
+import org.junit.jupiter.api.RepeatedTest;
+import org.junit.jupiter.api.Test;
+
+import xyz.nucleoid.plasmid.api.game.common.team.TeamAllocator;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class TeamAllocatorTests {
+    private static final int REPEAT_COUNT = 30;
+
+    @RepeatedTest(REPEAT_COUNT)
+    public void singleAllocationWithNoPreference() {
+        var team = new Team("team");
+        var player = new Player("player");
+
+        assertAllocation(expected -> {
+            expected.put(team, player);
+        }, allocator -> {
+            allocator.add(player, null);
+        });
+    }
+
+    @RepeatedTest(REPEAT_COUNT)
+    public void singleAllocationWithPreference() {
+        var team = new Team("team");
+        var player = new Player("player");
+
+        assertAllocation(expected -> {
+            expected.put(team, player);
+        }, allocator -> {
+            allocator.add(player, team);
+        });
+    }
+
+    @RepeatedTest(REPEAT_COUNT)
+    public void twoAllocationWithPartialPreference() {
+        var team1 = new Team("team1");
+        var team2 = new Team("team2");
+
+        var player1 = new Player("player1");
+        var player2 = new Player("player2");
+
+        assertAllocation(expected -> {
+            expected.put(team1, player1);
+            expected.put(team2, player2);
+        }, allocator -> {
+            allocator.add(player1, team1);
+            allocator.add(player2, null);
+        });
+    }
+
+    @RepeatedTest(REPEAT_COUNT)
+    public void twoAllocationWithPreference() {
+        var team1 = new Team("team1");
+        var team2 = new Team("team2");
+
+        var player1 = new Player("player1");
+        var player2 = new Player("player2");
+
+        assertAllocation(expected -> {
+            expected.put(team1, player2);
+            expected.put(team2, player1);
+        }, allocator -> {
+            allocator.add(player1, team2);
+            allocator.add(player2, team1);
+        });
+    }
+
+    @RepeatedTest(REPEAT_COUNT)
+    public void fourAllocationWithPartialPreference() {
+        var team1 = new Team("team1");
+        var team2 = new Team("team2");
+
+        var player1 = new Player("player1");
+        var player2 = new Player("player2");
+        var player3 = new Player("player3");
+        var player4 = new Player("player4");
+
+        assertAllocation(expected -> {
+            expected.put(team1, player1);
+            expected.put(team1, player2);
+            expected.put(team2, player3);
+            expected.put(team2, player4);
+        }, allocator -> {
+            allocator.add(player1, team1);
+            allocator.add(player2, team1);
+            allocator.add(player3, team2);
+            allocator.add(player4, null);
+        });
+    }
+
+    @RepeatedTest(REPEAT_COUNT)
+    public void fourAllocationWithPreference() {
+        var team1 = new Team("team1");
+        var team2 = new Team("team2");
+
+        var player1 = new Player("player1");
+        var player2 = new Player("player2");
+        var player3 = new Player("player3");
+        var player4 = new Player("player4");
+
+        assertAllocation(expected -> {
+            expected.put(team1, player2);
+            expected.put(team1, player4);
+            expected.put(team2, player1);
+            expected.put(team2, player3);
+        }, allocator -> {
+            allocator.add(player1, team2);
+            allocator.add(player2, team1);
+            allocator.add(player3, team2);
+            allocator.add(player4, team1);
+        });
+    }
+
+    @RepeatedTest(REPEAT_COUNT)
+    public void groupingAllocation() {
+        var team1 = new Team("team1");
+        var team2 = new Team("team2");
+
+        var player1 = new Player("player1");
+        var player2 = new Player("player2");
+        var player3 = new Player("player3");
+        var player4 = new Player("player4");
+
+        assertAllocation(allocator -> {
+            allocator.add(player1, null);
+            allocator.add(player2, null);
+            allocator.add(player3, null);
+            allocator.add(player4, null);
+
+            allocator.group(Set.of(player1, player3));
+            allocator.group(Set.of(player2, player4));
+        }, Set.of(team1, team2), actual -> {
+            var team1Players = actual.get(team1);
+            var team2Players = actual.get(team2);
+
+            if (team1Players.contains(player1)) {
+                assertTrue(team1Players.contains(player3), "expected player3 to be in team1");
+
+                assertTrue(team2Players.contains(player2), "expected player2 to be in team2");
+                assertTrue(team2Players.contains(player4), "expected player4 to be in team2");
+            } else if (team2Players.contains(player1)) {
+                assertTrue(team2Players.contains(player3), "expected player3 to be in team2");
+
+                assertTrue(team1Players.contains(player2), "expected player2 to be in team1");
+                assertTrue(team1Players.contains(player4), "expected player4 to be in team1");
+            } else {
+                fail("expected player1 to be in team1 or team2");
+            }
+        });
+    }
+
+    @Test
+    public void cannotAllocateWithNoTeams() {
+        assertThrows(IllegalArgumentException.class, () -> {
+            createAllocator(Set.of());
+        });
+    }
+
+    @Test
+    public void cannotGroupUnaddedPlayer() {
+        var team = new Team("team");
+        var player = new Player("player");
+
+        var allocator = createAllocator(Set.of(team));
+
+        assertThrows(IllegalArgumentException.class, () -> {
+            allocator.group(Set.of(player));
+        });
+    }
+
+    @Test
+    public void cannotRegroupPlayer() {
+        var team = new Team("team");
+        var player = new Player("player");
+
+        var allocator = createAllocator(Set.of(team));
+
+        assertThrows(IllegalStateException.class, () -> {
+            allocator.add(player, null);
+
+            allocator.group(Set.of(player));
+            allocator.group(Set.of(player));
+        });
+    }
+
+    private static void assertAllocation(Consumer<TeamAllocator<Team, Player>> allocatorInitializer, Set<Team> teams, Consumer<Multimap<Team, Player>> validator) {
+        var allocator = createAllocator(teams);
+        allocatorInitializer.accept(allocator);
+
+        var actual = allocator.allocate();
+        validator.accept(actual);
+    }
+
+    private static void assertAllocation(Consumer<ImmutableMultimap.Builder<Team, Player>> expectedInitializer, Consumer<TeamAllocator<Team, Player>> allocatorInitializer) {
+        var expectedBuilder = ImmutableMultimap.<Team, Player>builder();
+        expectedInitializer.accept(expectedBuilder);
+
+        var expected = expectedBuilder.build();
+
+        var teams = expected.keySet();
+
+        assertAllocation(allocatorInitializer, teams, actual -> {
+            assertMultimapsEqual(expected, actual);
+        });
+    }
+
+    private static void assertMultimapsEqual(Multimap<Team, Player> expected, Multimap<Team, Player> actual) {
+        assertTrue(expected.keySet().equals(actual.keySet()), "expected teams " + expected.keySet() + " but got " + actual.keySet());
+
+        for (Team key : expected.keySet()) {
+            var expectedValue = expected.get(key);
+            var actualValue = actual.get(key);
+
+            Supplier<String> messageSupplier = () -> {
+                return "expected team " + key.id() + " to contain " + expectedValue + ", but got " + actualValue;
+            };
+
+            assertTrue(expectedValue.containsAll(actualValue), messageSupplier);
+            assertTrue(actualValue.containsAll(expectedValue), messageSupplier);
+        }
+    }
+
+    private static TeamAllocator<Team, Player> createAllocator(Collection<Team> teams) {
+        return new TeamAllocator<>(teams);
+    }
+
+    record Team(String id) {}
+    record Player(String id) {}
+}


### PR DESCRIPTION
This pull request introduces grouping functionality for team allocators and a finalize event that allows other mods to apply groups to team allocators. This functionality is useful for game party mods that should place players in the same party on the same team within games.