### PR TITLE
Add sword blocking to old combat

### DIFF
--- a/src/main/java/xyz/nucleoid/plasmid/impl/Plasmid.java
+++ b/src/main/java/xyz/nucleoid/plasmid/impl/Plasmid.java
@@ -39,6 +39,7 @@ import xyz.nucleoid.plasmid.impl.portal.game.NewGamePortalConfig;
 import xyz.nucleoid.plasmid.impl.portal.game.SingleGamePortalConfig;
 import xyz.nucleoid.plasmid.impl.command.*;
 import xyz.nucleoid.plasmid.impl.compatibility.TrinketsCompatibility;
+import xyz.nucleoid.plasmid.impl.component.PlasmidDataComponentTypes;
 import xyz.nucleoid.plasmid.impl.portal.menu.*;
 
 public final class Plasmid implements ModInitializer {
@@ -66,6 +67,8 @@ public final class Plasmid implements ModInitializer {
             var id = context.server().getRegistryManager().getOrThrow(GameConfigs.REGISTRY_KEY).getId(context.game());
             throw new GameOpenException(Text.translatable("text.plasmid.map.open.invalid_game", id != null ? id.toString() : context.game()));
         });
+
+        PlasmidDataComponentTypes.register();
 
         this.registerCallbacks();
 

--- a/src/main/java/xyz/nucleoid/plasmid/impl/component/PlasmidDataComponentTypes.java
+++ b/src/main/java/xyz/nucleoid/plasmid/impl/component/PlasmidDataComponentTypes.java
@@ -1,0 +1,26 @@
+package xyz.nucleoid.plasmid.impl.component;
+
+import eu.pb4.polymer.core.api.other.PolymerComponent;
+import net.minecraft.component.ComponentType;
+import net.minecraft.registry.Registries;
+import net.minecraft.registry.Registry;
+import net.minecraft.util.Identifier;
+import net.minecraft.util.Unit;
+import xyz.nucleoid.plasmid.impl.Plasmid;
+
+public final class PlasmidDataComponentTypes {
+    private PlasmidDataComponentTypes() {
+    }
+
+    public static final ComponentType<Unit> OLD_COMBAT = register("old_combat", ComponentType.<Unit>builder()
+            .codec(Unit.CODEC)
+            .build());
+
+    private static <T> ComponentType<T> register(String path, ComponentType<T> type) {
+        return Registry.register(Registries.DATA_COMPONENT_TYPE, Identifier.of(Plasmid.ID, path), type);
+    }
+
+    public static void register() {
+        PolymerComponent.registerDataComponent(OLD_COMBAT);
+    }
+}

--- a/src/main/java/xyz/nucleoid/plasmid/mixin/game/common/LivingEntityMixin.java
+++ b/src/main/java/xyz/nucleoid/plasmid/mixin/game/common/LivingEntityMixin.java
@@ -1,0 +1,75 @@
+package xyz.nucleoid.plasmid.mixin.game.common;
+
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import com.llamalad7.mixinextras.sugar.Local;
+import com.llamalad7.mixinextras.sugar.ref.LocalFloatRef;
+import net.minecraft.entity.LivingEntity;
+import net.minecraft.entity.damage.DamageSource;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.Items;
+import net.minecraft.item.ShieldItem;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Constant;
+import org.spongepowered.asm.mixin.injection.ModifyConstant;
+import xyz.nucleoid.plasmid.impl.component.PlasmidDataComponentTypes;
+
+@Mixin(LivingEntity.class)
+public class LivingEntityMixin {
+    @Shadow
+    @Final
+    private ItemStack activeItemStack;
+
+    @WrapOperation(
+            method = "blockedByShield",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lnet/minecraft/item/ItemStack;getItem()Lnet/minecraft/item/Item;"
+            )
+    )
+    private Item allowOldCombatSwordBlocking(ItemStack stack, Operation<Item> operation) {
+        // Allow fulfilling the instanceof ShieldItem check
+        if (stack.contains(PlasmidDataComponentTypes.OLD_COMBAT)) {
+            return Items.SHIELD;
+        }
+
+        return operation.call(stack);
+    }
+
+    @WrapOperation(
+            method = "damage",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lnet/minecraft/entity/LivingEntity;blockedByShield(Lnet/minecraft/entity/damage/DamageSource;)Z"
+            )
+    )
+    private boolean applyHalfDamageFromSwordBlocking(LivingEntity entity, DamageSource source, Operation<Boolean> operation, @Local(ordinal = 0, argsOnly = true) LocalFloatRef amount) {
+        if (operation.call(entity, source)) {
+            ItemStack stack = entity.getBlockingItem();
+
+            if (!stack.contains(PlasmidDataComponentTypes.OLD_COMBAT) || stack.getItem() instanceof ShieldItem) {
+                return true;
+            }
+
+            amount.set(Math.max(0, (amount.get() / 2) - 0.5f));
+        }
+
+        return false;
+    }
+
+    @ModifyConstant(
+            method = "getBlockingItem",
+            constant = @Constant(intValue = 5)
+    )
+    private int allowInstantSwordBlocking(int original) {
+        if (!this.activeItemStack.contains(PlasmidDataComponentTypes.OLD_COMBAT) || this.activeItemStack.getItem() instanceof ShieldItem) {
+            return original;
+        }
+
+        return 0;
+    }
+}

--- a/src/main/resources/plasmid.mixins.json
+++ b/src/main/resources/plasmid.mixins.json
@@ -8,6 +8,7 @@
     "chat.PlayerEntityMixin",
     "chat.PlayerListS2CPacketEntryAccessor",
     "chat.ServerPlayerEntityMixin",
+    "game.common.LivingEntityMixin",
     "game.portal.EntityMixin",
     "game.portal.SignBlockEntityMixin",
     "game.rule.EquippableComponentMixin",


### PR DESCRIPTION
This pull request will be part of a series of changes to expand the old combat systems to bring it further in line with Minecraft 1.8.9's combat system. As part of this pull request, old combat will now add blocking to swords, with the following behaviors:

- Blocks half damage in addition to a base of 0.5
- Does not damage the sword when blocking
- Blocks immediately, as opposed to after 0.25 seconds
- Plays damage sounds as opposed to shield sounds

The `plasmid:old_combat` data component type introduced as part of this pull request should be considered an implementation detail. Games should not expect to persist this component as its format may change in the future.