### PR TITLE
Fix client-side team colors (Minecraft 1.21.1)

### DIFF
--- a/src/main/java/xyz/nucleoid/plasmid/api/game/common/team/TeamManager.java
+++ b/src/main/java/xyz/nucleoid/plasmid/api/game/common/team/TeamManager.java
@@ -138,6 +138,9 @@ public final class TeamManager implements Iterable<GameTeam> {
         }
 
         this.playerToTeam.put(player.id(), team);
+        for (var gameSpacePlayer : gameSpace.getPlayers()) {
+            this.sendTeamsToPlayer(gameSpacePlayer);
+        }
 
         var state = this.teamState(team);
         if (state.allPlayers.add(player)) {
@@ -192,6 +195,7 @@ public final class TeamManager implements Iterable<GameTeam> {
 
         var entity = state.onlinePlayers.getEntity(player.id());
         if (entity != null) {
+            this.sendRemoveTeamsForPlayer(entity);
             this.removeOnlinePlayer(entity, state);
         }
         return true;


### PR DESCRIPTION
The teams weren't being sent to the client when players were added/removed, causing the team colors to display as white on the client-side (in nametags and the player list).