### PR TITLE
Feature: Allow force starting games

### DIFF
--- a/src/main/java/xyz/nucleoid/plasmid/api/game/common/GameWaitingLobby.java
+++ b/src/main/java/xyz/nucleoid/plasmid/api/game/common/GameWaitingLobby.java
@@ -221,10 +221,6 @@ public final class GameWaitingLobby {
 
     @Nullable
     private GameResult requestStart() {
-        if (this.gameSpace.getPlayers().participants().size() < this.playerConfig.minPlayers()) {
-            return GameResult.error(GameTexts.Start.notEnoughPlayers());
-        }
-
         if (!this.started) {
             // consume the start request but initiate countdown
             this.startRequested = true;


### PR DESCRIPTION
Allows /game start to force start a game with a WaitingLobby even when it does not meet the minimum player requirements