### PR TITLE
Fix test games missing entity data

### DIFF
--- a/src/testmod/java/xyz/nucleoid/plasmid/test/TestGame.java
+++ b/src/testmod/java/xyz/nucleoid/plasmid/test/TestGame.java
@@ -223,6 +223,7 @@ public final class TestGame {
         armorStandNbt.putBoolean("NoGravity", true);
 
         var armorStandPos = Vec3d.ofBottomCenter(edge.offset(Direction.WEST));
+        armorStandNbt.put("Pos", Vec3d.CODEC, armorStandPos);
         template.addEntity(new MapEntity(armorStandPos, armorStandNbt));
 
         for (var pos : bounds) {


### PR DESCRIPTION
The template would make everything crash due to an entity missing its position in its NBT compound