### PR TITLE
Refactor registries

### DIFF
--- a/src/main/java/xyz/nucleoid/plasmid/api/chat/PlasmidMessageTypes.java
+++ b/src/main/java/xyz/nucleoid/plasmid/api/chat/PlasmidMessageTypes.java
@@ -6,9 +6,9 @@ import net.minecraft.registry.RegistryKeys;
 import xyz.nucleoid.plasmid.impl.Plasmid;
 
 public final class PlasmidMessageTypes {
-    public static final RegistryKey<MessageType> TEAM_CHAT = register("team_chat");
+    public static final RegistryKey<MessageType> TEAM_CHAT = createKey("team_chat");
 
-    private static RegistryKey<MessageType> register(String key) {
+    private static RegistryKey<MessageType> createKey(String key) {
         return RegistryKey.of(RegistryKeys.MESSAGE_TYPE, Plasmid.id(key));
     }
 }

--- a/src/main/java/xyz/nucleoid/plasmid/api/chat/PlasmidMessageTypes.java
+++ b/src/main/java/xyz/nucleoid/plasmid/api/chat/PlasmidMessageTypes.java
@@ -3,9 +3,12 @@ package xyz.nucleoid.plasmid.api.chat;
 import net.minecraft.network.message.MessageType;
 import net.minecraft.registry.RegistryKey;
 import net.minecraft.registry.RegistryKeys;
-import net.minecraft.util.Identifier;
 import xyz.nucleoid.plasmid.impl.Plasmid;
 
 public final class PlasmidMessageTypes {
-    public static final RegistryKey<MessageType> TEAM_CHAT = RegistryKey.of(RegistryKeys.MESSAGE_TYPE, Identifier.of(Plasmid.ID, "team_chat"));
+    public static final RegistryKey<MessageType> TEAM_CHAT = register("team_chat");
+
+    private static RegistryKey<MessageType> register(String key) {
+        return RegistryKey.of(RegistryKeys.MESSAGE_TYPE, Plasmid.id(key));
+    }
 }

--- a/src/main/java/xyz/nucleoid/plasmid/api/game/GameType.java
+++ b/src/main/java/xyz/nucleoid/plasmid/api/game/GameType.java
@@ -1,13 +1,13 @@
 package xyz.nucleoid.plasmid.api.game;
 
 import com.mojang.serialization.MapCodec;
-import net.minecraft.registry.Registry;
 import net.minecraft.text.Text;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.Util;
 import org.jetbrains.annotations.Nullable;
 import xyz.nucleoid.plasmid.api.game.config.GameConfig;
 import xyz.nucleoid.plasmid.api.registry.PlasmidRegistries;
+import xyz.nucleoid.plasmid.api.util.TinyRegistry;
 
 import java.util.function.Consumer;
 
@@ -26,7 +26,7 @@ public final class GameType<C> {
      * @deprecated Use {@link PlasmidRegistries#GAME_TYPE} instead.
      */
     @Deprecated
-    public static final Registry<GameType<?>> REGISTRY = PlasmidRegistries.GAME_TYPE;
+    public static final TinyRegistry<GameType<?>> REGISTRY = new TinyRegistry.Fake(PlasmidRegistries.GAME_TYPE);
 
     private final Identifier id;
     private final MapCodec<C> configCodec;

--- a/src/main/java/xyz/nucleoid/plasmid/api/game/GameType.java
+++ b/src/main/java/xyz/nucleoid/plasmid/api/game/GameType.java
@@ -1,13 +1,13 @@
 package xyz.nucleoid.plasmid.api.game;
 
 import com.mojang.serialization.MapCodec;
+import net.minecraft.registry.Registry;
 import net.minecraft.text.Text;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.Util;
 import org.jetbrains.annotations.Nullable;
 import xyz.nucleoid.plasmid.api.game.config.GameConfig;
 import xyz.nucleoid.plasmid.api.registry.PlasmidRegistries;
-import xyz.nucleoid.plasmid.api.util.TinyRegistry;
 
 import java.util.function.Consumer;
 
@@ -26,7 +26,7 @@ public final class GameType<C> {
      * @deprecated Use {@link PlasmidRegistries#GAME_TYPE} instead.
      */
     @Deprecated
-    public static final TinyRegistry<GameType<?>> REGISTRY = PlasmidRegistries.GAME_TYPE;
+    public static final Registry<GameType<?>> REGISTRY = PlasmidRegistries.GAME_TYPE;
 
     private final Identifier id;
     private final MapCodec<C> configCodec;
@@ -53,9 +53,7 @@ public final class GameType<C> {
      */
     @Deprecated
     public static <C> GameType<C> register(Identifier identifier, MapCodec<C> configCodec, Open<C> open) {
-        var type = new GameType<>(identifier, configCodec, open);
-        PlasmidRegistries.GAME_TYPE.register(identifier, type);
-        return type;
+        return GameTypes.register(identifier, configCodec, open);
     }
 
     public GameOpenProcedure open(GameOpenContext<C> context) {

--- a/src/main/java/xyz/nucleoid/plasmid/api/game/GameType.java
+++ b/src/main/java/xyz/nucleoid/plasmid/api/game/GameType.java
@@ -6,6 +6,7 @@ import net.minecraft.util.Identifier;
 import net.minecraft.util.Util;
 import org.jetbrains.annotations.Nullable;
 import xyz.nucleoid.plasmid.api.game.config.GameConfig;
+import xyz.nucleoid.plasmid.api.registry.PlasmidRegistries;
 import xyz.nucleoid.plasmid.api.util.TinyRegistry;
 
 import java.util.function.Consumer;
@@ -21,13 +22,17 @@ import java.util.function.Consumer;
  * @see GameConfig
  */
 public final class GameType<C> {
-    public static final TinyRegistry<GameType<?>> REGISTRY = TinyRegistry.create();
+    /**
+     * @deprecated Use {@link PlasmidRegistries#GAME_TYPE} instead.
+     */
+    @Deprecated
+    public static final TinyRegistry<GameType<?>> REGISTRY = PlasmidRegistries.GAME_TYPE;
 
     private final Identifier id;
     private final MapCodec<C> configCodec;
     private final Open<C> open;
 
-    private GameType(Identifier id, MapCodec<C> configCodec, Open<C> open) {
+    GameType(Identifier id, MapCodec<C> configCodec, Open<C> open) {
         this.id = id;
         this.configCodec = configCodec;
         this.open = open;
@@ -43,10 +48,13 @@ public final class GameType<C> {
      * @return the registered {@link GameType} instance
      * @see MapCodec
      * @see com.mojang.serialization.codecs.RecordCodecBuilder
+     *
+     * @deprecated Use {@link GameTypes#register(Identifier, MapCodec, Open)} instead.
      */
+    @Deprecated
     public static <C> GameType<C> register(Identifier identifier, MapCodec<C> configCodec, Open<C> open) {
         var type = new GameType<>(identifier, configCodec, open);
-        REGISTRY.register(identifier, type);
+        PlasmidRegistries.GAME_TYPE.register(identifier, type);
         return type;
     }
 
@@ -72,7 +80,7 @@ public final class GameType<C> {
 
     @Nullable
     public static GameType<?> get(Identifier identifier) {
-        return REGISTRY.get(identifier);
+        return PlasmidRegistries.GAME_TYPE.get(identifier);
     }
 
     public interface Open<C> {

--- a/src/main/java/xyz/nucleoid/plasmid/api/game/GameTypes.java
+++ b/src/main/java/xyz/nucleoid/plasmid/api/game/GameTypes.java
@@ -1,0 +1,33 @@
+package xyz.nucleoid.plasmid.api.game;
+
+import com.mojang.serialization.MapCodec;
+import net.minecraft.registry.Registry;
+import net.minecraft.text.Text;
+import net.minecraft.util.Identifier;
+import xyz.nucleoid.plasmid.api.registry.PlasmidRegistries;
+import xyz.nucleoid.plasmid.api.registry.PlasmidRegistryKeys;
+import xyz.nucleoid.plasmid.impl.Plasmid;
+import xyz.nucleoid.plasmid.impl.game.composite.RandomGame;
+import xyz.nucleoid.plasmid.impl.game.composite.RandomGameConfig;
+
+public class GameTypes {
+    public static final GameType<RandomGameConfig> RANDOM = register("random", RandomGameConfig.CODEC, RandomGame::open);
+    public static final GameType<String> INVALID = register("invalid", MapCodec.unit(""), (context) -> {
+        var id = context.server().getRegistryManager().getOrThrow(PlasmidRegistryKeys.GAME_CONFIG).getId(context.game());
+        throw new GameOpenException(Text.translatable("text.plasmid.map.open.invalid_game", id != null ? id.toString() : context.game()));
+    });
+
+    public static GameType<?> register(Identifier key, GameType<?> type) {
+        return Registry.register(PlasmidRegistries.GAME_TYPE, key, type);
+    }
+
+    public static <C> GameType<C> register(Identifier key, MapCodec<C> configCodec, GameType.Open<C> open) {
+        var type = new GameType<>(key, configCodec, open);
+        register(key, type);
+        return type;
+    }
+
+    public static <C> GameType<C> register(String key, MapCodec<C> configCodec, GameType.Open<C> open) {
+        return register(Plasmid.id(key), configCodec, open);
+    }
+}

--- a/src/main/java/xyz/nucleoid/plasmid/api/game/config/GameConfig.java
+++ b/src/main/java/xyz/nucleoid/plasmid/api/game/config/GameConfig.java
@@ -1,14 +1,14 @@
 package xyz.nucleoid.plasmid.api.game.config;
 
 import com.mojang.serialization.Codec;
-import com.mojang.serialization.DataResult;
 import com.mojang.serialization.MapCodec;
-import com.mojang.serialization.codecs.KeyDispatchCodec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.Items;
+import net.minecraft.registry.RegistryCodecs;
 import net.minecraft.registry.entry.RegistryElementCodec;
 import net.minecraft.registry.entry.RegistryEntry;
+import net.minecraft.registry.entry.RegistryEntryList;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.text.Text;
 import net.minecraft.util.Identifier;
@@ -18,6 +18,8 @@ import xyz.nucleoid.codecs.MoreCodecs;
 import xyz.nucleoid.plasmid.api.game.GameOpenContext;
 import xyz.nucleoid.plasmid.api.game.GameOpenProcedure;
 import xyz.nucleoid.plasmid.api.game.GameType;
+import xyz.nucleoid.plasmid.api.registry.PlasmidRegistries;
+import xyz.nucleoid.plasmid.api.registry.PlasmidRegistryKeys;
 import xyz.nucleoid.plasmid.api.util.PlasmidCodecs;
 import xyz.nucleoid.plasmid.impl.Plasmid;
 import xyz.nucleoid.plasmid.impl.PlasmidConfig;
@@ -38,13 +40,13 @@ public record GameConfig<C>(
         CustomValuesConfig custom,
         C config
 ) {
-    public static final Codec<GameConfig<?>> DIRECT_CODEC = GameType.REGISTRY.dispatch(GameConfig::type, GameConfig::createTypedCodec);
+    public static final Codec<GameConfig<?>> DIRECT_CODEC = PlasmidRegistries.GAME_TYPE.dispatch(GameConfig::type, GameConfig::createTypedCodec);
     @Deprecated
     public static final Codec<GameConfig<?>> REGISTRY_CODEC = Codec.lazyInitialized(() -> {
         if (!PlasmidConfig.get().ignoreInvalidGames()) {
             return DIRECT_CODEC;
         }
-        var type = (GameType<Object>) GameType.REGISTRY.get(Identifier.of(Plasmid.ID, "invalid"));
+        var type = (GameType<Object>) PlasmidRegistries.GAME_TYPE.get(Identifier.of(Plasmid.ID, "invalid"));
 
         return Codec.withAlternative(DIRECT_CODEC, Codec.unit(() -> new GameConfig<>(
                 type,
@@ -56,7 +58,13 @@ public record GameConfig<C>(
                 ""
         )));
     });
-    public static final Codec<RegistryEntry<GameConfig<?>>> CODEC = RegistryElementCodec.of(GameConfigs.REGISTRY_KEY, DIRECT_CODEC);
+    public static final Codec<RegistryEntry<GameConfig<?>>> ENTRY_CODEC = RegistryElementCodec.of(PlasmidRegistryKeys.GAME_CONFIG, DIRECT_CODEC);
+    public static final Codec<RegistryEntryList<GameConfig<?>>> ENTRY_LIST_CODEC = RegistryCodecs.entryList(PlasmidRegistryKeys.GAME_CONFIG);
+    /**
+     * @deprecated Use {@link #ENTRY_CODEC} instead.
+     */
+    @Deprecated
+    public static final Codec<RegistryEntry<GameConfig<?>>> CODEC = ENTRY_CODEC;
 
     public static GameOpenProcedure openProcedure(MinecraftServer server, RegistryEntry<GameConfig<?>> config) {
         //noinspection unchecked,rawtypes

--- a/src/main/java/xyz/nucleoid/plasmid/api/game/config/GameConfig.java
+++ b/src/main/java/xyz/nucleoid/plasmid/api/game/config/GameConfig.java
@@ -29,7 +29,6 @@ import xyz.nucleoid.server.translations.api.language.ServerLanguageDefinition;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
-import java.util.function.Consumer;
 
 public record GameConfig<C>(
         GameType<C> type,
@@ -40,7 +39,7 @@ public record GameConfig<C>(
         CustomValuesConfig custom,
         C config
 ) {
-    public static final Codec<GameConfig<?>> DIRECT_CODEC = PlasmidRegistries.GAME_TYPE.dispatch(GameConfig::type, GameConfig::createTypedCodec);
+    public static final Codec<GameConfig<?>> DIRECT_CODEC = PlasmidRegistries.GAME_TYPE.getCodec().dispatch(GameConfig::type, GameConfig::createTypedCodec);
     @Deprecated
     public static final Codec<GameConfig<?>> REGISTRY_CODEC = Codec.lazyInitialized(() -> {
         if (!PlasmidConfig.get().ignoreInvalidGames()) {

--- a/src/main/java/xyz/nucleoid/plasmid/api/game/config/GameConfig.java
+++ b/src/main/java/xyz/nucleoid/plasmid/api/game/config/GameConfig.java
@@ -11,17 +11,16 @@ import net.minecraft.registry.entry.RegistryEntry;
 import net.minecraft.registry.entry.RegistryEntryList;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.text.Text;
-import net.minecraft.util.Identifier;
 import net.minecraft.util.Util;
 import org.jetbrains.annotations.Nullable;
 import xyz.nucleoid.codecs.MoreCodecs;
 import xyz.nucleoid.plasmid.api.game.GameOpenContext;
 import xyz.nucleoid.plasmid.api.game.GameOpenProcedure;
 import xyz.nucleoid.plasmid.api.game.GameType;
+import xyz.nucleoid.plasmid.api.game.GameTypes;
 import xyz.nucleoid.plasmid.api.registry.PlasmidRegistries;
 import xyz.nucleoid.plasmid.api.registry.PlasmidRegistryKeys;
 import xyz.nucleoid.plasmid.api.util.PlasmidCodecs;
-import xyz.nucleoid.plasmid.impl.Plasmid;
 import xyz.nucleoid.plasmid.impl.PlasmidConfig;
 import xyz.nucleoid.server.translations.api.language.ServerLanguage;
 import xyz.nucleoid.server.translations.api.language.ServerLanguageDefinition;
@@ -45,10 +44,9 @@ public record GameConfig<C>(
         if (!PlasmidConfig.get().ignoreInvalidGames()) {
             return DIRECT_CODEC;
         }
-        var type = (GameType<Object>) PlasmidRegistries.GAME_TYPE.get(Identifier.of(Plasmid.ID, "invalid"));
 
         return Codec.withAlternative(DIRECT_CODEC, Codec.unit(() -> new GameConfig<>(
-                type,
+                GameTypes.INVALID,
                 null,
                 null,
                 null,

--- a/src/main/java/xyz/nucleoid/plasmid/api/game/config/GameConfigs.java
+++ b/src/main/java/xyz/nucleoid/plasmid/api/game/config/GameConfigs.java
@@ -2,9 +2,12 @@ package xyz.nucleoid.plasmid.api.game.config;
 
 import net.minecraft.registry.Registry;
 import net.minecraft.registry.RegistryKey;
-import net.minecraft.util.Identifier;
-import xyz.nucleoid.plasmid.impl.Plasmid;
+import xyz.nucleoid.plasmid.api.registry.PlasmidRegistryKeys;
 
 public final class GameConfigs {
-    public static final RegistryKey<Registry<GameConfig<?>>> REGISTRY_KEY = RegistryKey.ofRegistry(Identifier.of(Plasmid.ID, "game"));
+    /**
+     * @deprecated Use {@link PlasmidRegistryKeys#GAME_CONFIG} instead.
+     */
+    @Deprecated
+    public static final RegistryKey<Registry<GameConfig<?>>> REGISTRY_KEY = PlasmidRegistryKeys.GAME_CONFIG;
 }

--- a/src/main/java/xyz/nucleoid/plasmid/api/game/stats/StatisticKeys.java
+++ b/src/main/java/xyz/nucleoid/plasmid/api/game/stats/StatisticKeys.java
@@ -28,7 +28,7 @@ public final class StatisticKeys {
     public static final StatisticKey<Integer> LONGEST_TIME = StatisticKey.intKey(id("longest_time"));
 
     private static Identifier id(String path) {
-        return Identifier.of(Plasmid.ID, path);
+        return Plasmid.id(path);
     }
     private StatisticKeys() { }
 }

--- a/src/main/java/xyz/nucleoid/plasmid/api/portal/GamePortalConfigs.java
+++ b/src/main/java/xyz/nucleoid/plasmid/api/portal/GamePortalConfigs.java
@@ -1,0 +1,32 @@
+package xyz.nucleoid.plasmid.api.portal;
+
+import com.mojang.serialization.MapCodec;
+import net.minecraft.registry.Registry;
+import net.minecraft.util.Identifier;
+import xyz.nucleoid.plasmid.api.registry.PlasmidRegistries;
+import xyz.nucleoid.plasmid.impl.Plasmid;
+import xyz.nucleoid.plasmid.impl.portal.GamePortalConfig;
+import xyz.nucleoid.plasmid.impl.portal.game.ConcurrentGamePortalConfig;
+import xyz.nucleoid.plasmid.impl.portal.game.LegacyOnDemandPortalConfig;
+import xyz.nucleoid.plasmid.impl.portal.game.NewGamePortalConfig;
+import xyz.nucleoid.plasmid.impl.portal.game.SingleGamePortalConfig;
+import xyz.nucleoid.plasmid.impl.portal.menu.AdvancedMenuPortalConfig;
+import xyz.nucleoid.plasmid.impl.portal.menu.MenuPortalConfig;
+
+public class GamePortalConfigs {
+    public static MapCodec<? extends GamePortalConfig> SINGLE_GAME = register("single_game", SingleGamePortalConfig.CODEC);
+    public static MapCodec<? extends GamePortalConfig> NEW_GAME = register("new_game", NewGamePortalConfig.CODEC);
+    public static MapCodec<? extends GamePortalConfig> CONCURRENT_GAME = register("concurrent_game", ConcurrentGamePortalConfig.CODEC);
+    public static MapCodec<? extends GamePortalConfig> ON_DEMAND = register("on_demand", LegacyOnDemandPortalConfig.CODEC);
+
+    public static MapCodec<? extends GamePortalConfig> MENU = register("menu", MenuPortalConfig.CODEC);
+    public static MapCodec<? extends GamePortalConfig> ADVANCED_MENU = register("advanced_menu", AdvancedMenuPortalConfig.CODEC);
+
+    public static MapCodec<? extends GamePortalConfig> register(Identifier key, MapCodec<? extends GamePortalConfig> codec) {
+        return Registry.register(PlasmidRegistries.GAME_PORTAL_CONFIG, key, codec);
+    }
+
+    private static MapCodec<? extends GamePortalConfig> register(String key, MapCodec<? extends GamePortalConfig> codec) {
+        return register(Plasmid.id(key), codec);
+    }
+}

--- a/src/main/java/xyz/nucleoid/plasmid/api/portal/menu/MenuEntryConfigs.java
+++ b/src/main/java/xyz/nucleoid/plasmid/api/portal/menu/MenuEntryConfigs.java
@@ -1,0 +1,21 @@
+package xyz.nucleoid.plasmid.api.portal.menu;
+
+import com.mojang.serialization.MapCodec;
+import net.minecraft.registry.Registry;
+import net.minecraft.util.Identifier;
+import xyz.nucleoid.plasmid.api.registry.PlasmidRegistries;
+import xyz.nucleoid.plasmid.impl.Plasmid;
+import xyz.nucleoid.plasmid.impl.portal.menu.*;
+
+public class MenuEntryConfigs {
+    public static MapCodec<? extends MenuEntryConfig> GAME = register("game", GameMenuEntryConfig.CODEC);
+    public static MapCodec<? extends MenuEntryConfig> PORTAL = register("portal", PortalEntryConfig.CODEC);
+
+    public static MapCodec<? extends MenuEntryConfig> register(Identifier key, MapCodec<? extends MenuEntryConfig> codec) {
+        return Registry.register(PlasmidRegistries.MENU_ENTRY, key, codec);
+    }
+
+    private static MapCodec<? extends MenuEntryConfig> register(String key, MapCodec<? extends MenuEntryConfig> codec) {
+        return register(Plasmid.id(key), codec);
+    }
+}

--- a/src/main/java/xyz/nucleoid/plasmid/api/registry/PlasmidRegistries.java
+++ b/src/main/java/xyz/nucleoid/plasmid/api/registry/PlasmidRegistries.java
@@ -12,9 +12,9 @@ import xyz.nucleoid.plasmid.impl.portal.GamePortalConfig;
 import xyz.nucleoid.plasmid.impl.portal.menu.MenuEntryConfig;
 
 public class PlasmidRegistries {
-    public static final SimpleRegistry<GameType<?>> GAME_TYPE = register(PlasmidRegistryKeys.GAME_TYPE);
-    public static final SimpleRegistry<MapCodec<? extends GamePortalConfig>> GAME_PORTAL_CONFIG = register(PlasmidRegistryKeys.GAME_PORTAL_CONFIG);
-    public static final SimpleRegistry<MapCodec<? extends MenuEntryConfig>> MENU_ENTRY = register(PlasmidRegistryKeys.MENU_ENTRY);
+    public static final Registry<GameType<?>> GAME_TYPE = register(PlasmidRegistryKeys.GAME_TYPE);
+    public static final Registry<MapCodec<? extends GamePortalConfig>> GAME_PORTAL_CONFIG = register(PlasmidRegistryKeys.GAME_PORTAL_CONFIG);
+    public static final Registry<MapCodec<? extends MenuEntryConfig>> MENU_ENTRY = register(PlasmidRegistryKeys.MENU_ENTRY);
 
     private static <T> SimpleRegistry<T> register(RegistryKey<Registry<T>> key) {
         return FabricRegistryBuilder.createSimple(key).buildAndRegister();

--- a/src/main/java/xyz/nucleoid/plasmid/api/registry/PlasmidRegistries.java
+++ b/src/main/java/xyz/nucleoid/plasmid/api/registry/PlasmidRegistries.java
@@ -1,0 +1,26 @@
+package xyz.nucleoid.plasmid.api.registry;
+
+import com.mojang.serialization.MapCodec;
+import net.fabricmc.fabric.api.event.registry.DynamicRegistries;
+import net.fabricmc.fabric.api.event.registry.FabricRegistryBuilder;
+import net.minecraft.registry.Registry;
+import net.minecraft.registry.RegistryKey;
+import net.minecraft.registry.SimpleRegistry;
+import xyz.nucleoid.plasmid.api.game.GameType;
+import xyz.nucleoid.plasmid.api.game.config.GameConfig;
+import xyz.nucleoid.plasmid.impl.portal.GamePortalConfig;
+import xyz.nucleoid.plasmid.impl.portal.menu.MenuEntryConfig;
+
+public class PlasmidRegistries {
+    public static final SimpleRegistry<GameType<?>> GAME_TYPE = register(PlasmidRegistryKeys.GAME_TYPE);
+    public static final SimpleRegistry<MapCodec<? extends GamePortalConfig>> GAME_PORTAL_CONFIG = register(PlasmidRegistryKeys.GAME_PORTAL_CONFIG);
+    public static final SimpleRegistry<MapCodec<? extends MenuEntryConfig>> MENU_ENTRY = register(PlasmidRegistryKeys.MENU_ENTRY);
+
+    private static <T> SimpleRegistry<T> register(RegistryKey<Registry<T>> key) {
+        return FabricRegistryBuilder.createSimple(key).buildAndRegister();
+    }
+
+    public static void registerDynamicRegistries() {
+        DynamicRegistries.register(PlasmidRegistryKeys.GAME_CONFIG, GameConfig.REGISTRY_CODEC);
+    }
+}

--- a/src/main/java/xyz/nucleoid/plasmid/api/registry/PlasmidRegistryKeys.java
+++ b/src/main/java/xyz/nucleoid/plasmid/api/registry/PlasmidRegistryKeys.java
@@ -11,7 +11,7 @@ import xyz.nucleoid.plasmid.impl.portal.GamePortalConfig;
 import xyz.nucleoid.plasmid.impl.portal.menu.MenuEntryConfig;
 
 public class PlasmidRegistryKeys {
-    public static final RegistryKey<Registry<GameType<?>>> GAME_TYPE = register("game");
+    public static final RegistryKey<Registry<GameType<?>>> GAME_TYPE = register("game_type");
     public static final RegistryKey<Registry<MapCodec<? extends GamePortalConfig>>> GAME_PORTAL_CONFIG = register("game_portal_config");
     public static final RegistryKey<Registry<MapCodec<? extends MenuEntryConfig>>> MENU_ENTRY = register("menu_entry");
     public static final RegistryKey<Registry<GameConfig<?>>> GAME_CONFIG = register("game");

--- a/src/main/java/xyz/nucleoid/plasmid/api/registry/PlasmidRegistryKeys.java
+++ b/src/main/java/xyz/nucleoid/plasmid/api/registry/PlasmidRegistryKeys.java
@@ -17,6 +17,6 @@ public class PlasmidRegistryKeys {
     public static final RegistryKey<Registry<GameConfig<?>>> GAME_CONFIG = register("game");
 
     private static <T> RegistryKey<Registry<T>> register(String key) {
-        return RegistryKey.ofRegistry(Identifier.of(Plasmid.ID, key));
+        return RegistryKey.ofRegistry(Plasmid.id(key));
     }
 }

--- a/src/main/java/xyz/nucleoid/plasmid/api/registry/PlasmidRegistryKeys.java
+++ b/src/main/java/xyz/nucleoid/plasmid/api/registry/PlasmidRegistryKeys.java
@@ -1,0 +1,22 @@
+package xyz.nucleoid.plasmid.api.registry;
+
+import com.mojang.serialization.MapCodec;
+import net.minecraft.registry.Registry;
+import net.minecraft.registry.RegistryKey;
+import net.minecraft.util.Identifier;
+import xyz.nucleoid.plasmid.api.game.GameType;
+import xyz.nucleoid.plasmid.api.game.config.GameConfig;
+import xyz.nucleoid.plasmid.impl.Plasmid;
+import xyz.nucleoid.plasmid.impl.portal.GamePortalConfig;
+import xyz.nucleoid.plasmid.impl.portal.menu.MenuEntryConfig;
+
+public class PlasmidRegistryKeys {
+    public static final RegistryKey<Registry<GameType<?>>> GAME_TYPE = register("game");
+    public static final RegistryKey<Registry<MapCodec<? extends GamePortalConfig>>> GAME_PORTAL_CONFIG = register("game_portal_config");
+    public static final RegistryKey<Registry<MapCodec<? extends MenuEntryConfig>>> MENU_ENTRY = register("menu_entry");
+    public static final RegistryKey<Registry<GameConfig<?>>> GAME_CONFIG = register("game");
+
+    private static <T> RegistryKey<Registry<T>> register(String key) {
+        return RegistryKey.ofRegistry(Identifier.of(Plasmid.ID, key));
+    }
+}

--- a/src/main/java/xyz/nucleoid/plasmid/api/registry/PlasmidRegistryKeys.java
+++ b/src/main/java/xyz/nucleoid/plasmid/api/registry/PlasmidRegistryKeys.java
@@ -3,7 +3,6 @@ package xyz.nucleoid.plasmid.api.registry;
 import com.mojang.serialization.MapCodec;
 import net.minecraft.registry.Registry;
 import net.minecraft.registry.RegistryKey;
-import net.minecraft.util.Identifier;
 import xyz.nucleoid.plasmid.api.game.GameType;
 import xyz.nucleoid.plasmid.api.game.config.GameConfig;
 import xyz.nucleoid.plasmid.impl.Plasmid;
@@ -11,12 +10,12 @@ import xyz.nucleoid.plasmid.impl.portal.GamePortalConfig;
 import xyz.nucleoid.plasmid.impl.portal.menu.MenuEntryConfig;
 
 public class PlasmidRegistryKeys {
-    public static final RegistryKey<Registry<GameType<?>>> GAME_TYPE = register("game_type");
-    public static final RegistryKey<Registry<MapCodec<? extends GamePortalConfig>>> GAME_PORTAL_CONFIG = register("game_portal_config");
-    public static final RegistryKey<Registry<MapCodec<? extends MenuEntryConfig>>> MENU_ENTRY = register("menu_entry");
-    public static final RegistryKey<Registry<GameConfig<?>>> GAME_CONFIG = register("game");
+    public static final RegistryKey<Registry<GameType<?>>> GAME_TYPE = createKey("game_type");
+    public static final RegistryKey<Registry<MapCodec<? extends GamePortalConfig>>> GAME_PORTAL_CONFIG = createKey("game_portal_config");
+    public static final RegistryKey<Registry<MapCodec<? extends MenuEntryConfig>>> MENU_ENTRY = createKey("menu_entry");
+    public static final RegistryKey<Registry<GameConfig<?>>> GAME_CONFIG = createKey("game");
 
-    private static <T> RegistryKey<Registry<T>> register(String key) {
+    private static <T> RegistryKey<Registry<T>> createKey(String key) {
         return RegistryKey.ofRegistry(Plasmid.id(key));
     }
 }

--- a/src/main/java/xyz/nucleoid/plasmid/api/util/TinyRegistry.java
+++ b/src/main/java/xyz/nucleoid/plasmid/api/util/TinyRegistry.java
@@ -6,13 +6,14 @@ import com.mojang.datafixers.util.Pair;
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.DataResult;
 import com.mojang.serialization.DynamicOps;
+import net.minecraft.registry.Registry;
 import net.minecraft.util.Identifier;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.Collection;
 import java.util.Set;
 
-public final class TinyRegistry<T> implements Codec<T> {
+public class TinyRegistry<T> implements Codec<T> {
     private final BiMap<Identifier, T> map = HashBiMap.create();
 
     private TinyRegistry() {
@@ -70,5 +71,58 @@ public final class TinyRegistry<T> implements Codec<T> {
 
     public Collection<T> values() {
         return this.map.values();
+    }
+
+    /**
+     * @deprecated allow the temporary use of a {@link Registry} as a {@link TinyRegistry}.
+     */
+    @Deprecated
+    public static class Fake<T> extends TinyRegistry<T> {
+        private final Registry<T> registry;
+
+        public Fake(Registry<T> registry) {
+            super();
+            this.registry = registry;
+        }
+
+        @Override
+        public void clear() {
+            // only used for GamePortalManager
+        }
+
+        @Override
+        public void register(Identifier identifier, T value) {
+            Registry.register(this.registry, identifier, value);
+        }
+
+        @Override
+        public @Nullable Identifier getIdentifier(T value) {
+            return this.registry.getId(value);
+        }
+
+        @Override
+        public boolean containsKey(Identifier identifier) {
+            return this.registry.containsId(identifier);
+        }
+
+        @Override
+        public <U> DataResult<Pair<T, U>> decode(DynamicOps<U> ops, U input) {
+            return this.registry.getCodec().decode(ops, input);
+        }
+
+        @Override
+        public <U> DataResult<U> encode(T input, DynamicOps<U> ops, U prefix) {
+            return this.registry.getCodec().encode(input, ops, prefix);
+        }
+
+        @Override
+        public Set<Identifier> keySet() {
+            return this.registry.getIds();
+        }
+
+        @Override
+        public Collection<T> values() {
+            return this.registry.stream().toList();
+        }
     }
 }

--- a/src/main/java/xyz/nucleoid/plasmid/impl/command/GameCommand.java
+++ b/src/main/java/xyz/nucleoid/plasmid/impl/command/GameCommand.java
@@ -18,6 +18,7 @@ import net.minecraft.text.MutableText;
 import net.minecraft.text.Text;
 import net.minecraft.util.Formatting;
 import org.slf4j.Logger;
+import xyz.nucleoid.plasmid.api.registry.PlasmidRegistryKeys;
 import xyz.nucleoid.plasmid.impl.Plasmid;
 import xyz.nucleoid.plasmid.impl.command.argument.GameConfigArgument;
 import xyz.nucleoid.plasmid.impl.command.argument.GameSpaceArgument;
@@ -27,7 +28,6 @@ import xyz.nucleoid.plasmid.api.game.GameOpenException;
 import xyz.nucleoid.plasmid.api.game.GameSpace;
 import xyz.nucleoid.plasmid.api.game.GameTexts;
 import xyz.nucleoid.plasmid.api.game.config.GameConfig;
-import xyz.nucleoid.plasmid.api.game.config.GameConfigs;
 import xyz.nucleoid.plasmid.impl.game.manager.GameSpaceManagerImpl;
 import xyz.nucleoid.plasmid.api.game.player.GamePlayerJoiner;
 import xyz.nucleoid.plasmid.api.game.player.JoinIntent;
@@ -408,7 +408,7 @@ public final class GameCommand {
     }
 
     private static int listGames(CommandContext<ServerCommandSource> context) {
-        var registry = context.getSource().getRegistryManager().getOrThrow(GameConfigs.REGISTRY_KEY);
+        var registry = context.getSource().getRegistryManager().getOrThrow(PlasmidRegistryKeys.GAME_CONFIG);
         var source = context.getSource();
         source.sendFeedback(() -> GameTexts.Command.gameList().formatted(Formatting.BOLD), false);
 

--- a/src/main/java/xyz/nucleoid/plasmid/impl/command/argument/GameConfigArgument.java
+++ b/src/main/java/xyz/nucleoid/plasmid/impl/command/argument/GameConfigArgument.java
@@ -13,7 +13,7 @@ import net.minecraft.server.command.ServerCommandSource;
 import net.minecraft.text.Text;
 import net.minecraft.util.Identifier;
 import xyz.nucleoid.plasmid.api.game.config.GameConfig;
-import xyz.nucleoid.plasmid.api.game.config.GameConfigs;
+import xyz.nucleoid.plasmid.api.registry.PlasmidRegistryKeys;
 
 import java.util.Locale;
 
@@ -25,7 +25,7 @@ public final class GameConfigArgument {
     public static RequiredArgumentBuilder<ServerCommandSource, Identifier> argument(String name) {
         return CommandManager.argument(name, IdentifierArgumentType.identifier())
                 .suggests((ctx, builder) -> {
-                    var registry = ctx.getSource().getRegistryManager().getOrThrow(GameConfigs.REGISTRY_KEY);
+                    var registry = ctx.getSource().getRegistryManager().getOrThrow(PlasmidRegistryKeys.GAME_CONFIG);
                     var remaining = builder.getRemaining().toLowerCase(Locale.ROOT);
 
                     CommandSource.forEachMatching(registry.getKeys(), remaining, RegistryKey::getValue, key -> {
@@ -38,8 +38,8 @@ public final class GameConfigArgument {
     }
 
     public static RegistryEntry.Reference<GameConfig<?>> get(CommandContext<ServerCommandSource> context, String name) throws CommandSyntaxException {
-        var key = RegistryKey.of(GameConfigs.REGISTRY_KEY, IdentifierArgumentType.getIdentifier(context, name));
-        var registry = context.getSource().getRegistryManager().getOrThrow(GameConfigs.REGISTRY_KEY);
+        var key = RegistryKey.of(PlasmidRegistryKeys.GAME_CONFIG, IdentifierArgumentType.getIdentifier(context, name));
+        var registry = context.getSource().getRegistryManager().getOrThrow(PlasmidRegistryKeys.GAME_CONFIG);
         return registry.getOptional(key).orElseThrow(() -> GAME_NOT_FOUND.create(key.getValue()));
     }
 }

--- a/src/main/java/xyz/nucleoid/plasmid/impl/game/composite/RandomGameConfig.java
+++ b/src/main/java/xyz/nucleoid/plasmid/impl/game/composite/RandomGameConfig.java
@@ -8,11 +8,11 @@ import net.minecraft.registry.entry.RegistryEntryList;
 import net.minecraft.util.math.random.Random;
 import org.jetbrains.annotations.Nullable;
 import xyz.nucleoid.plasmid.api.game.config.GameConfig;
-import xyz.nucleoid.plasmid.api.game.config.GameConfigs;
+import xyz.nucleoid.plasmid.api.registry.PlasmidRegistryKeys;
 
 public record RandomGameConfig(RegistryEntryList<GameConfig<?>> games) {
     public static final MapCodec<RandomGameConfig> CODEC = RecordCodecBuilder.mapCodec(i -> i.group(
-            RegistryCodecs.entryList(GameConfigs.REGISTRY_KEY).fieldOf("games").forGetter(config -> config.games)
+            GameConfig.ENTRY_LIST_CODEC.fieldOf("games").forGetter(config -> config.games)
     ).apply(i, RandomGameConfig::new));
 
     @Nullable

--- a/src/main/java/xyz/nucleoid/plasmid/impl/portal/GamePortalConfig.java
+++ b/src/main/java/xyz/nucleoid/plasmid/impl/portal/GamePortalConfig.java
@@ -2,19 +2,30 @@ package xyz.nucleoid.plasmid.impl.portal;
 
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.MapCodec;
+import net.minecraft.registry.SimpleRegistry;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.util.Identifier;
 import xyz.nucleoid.plasmid.api.game.config.CustomValuesConfig;
+import xyz.nucleoid.plasmid.api.portal.GamePortalConfigs;
+import xyz.nucleoid.plasmid.api.registry.PlasmidRegistries;
 import xyz.nucleoid.plasmid.api.util.TinyRegistry;
 
 import java.util.function.Function;
 
 public interface GamePortalConfig {
-    TinyRegistry<MapCodec<? extends GamePortalConfig>> REGISTRY = TinyRegistry.create();
-    Codec<GamePortalConfig> CODEC = REGISTRY.dispatchStable(GamePortalConfig::codec, Function.identity());
+    /**
+     * @deprecated Use {@link PlasmidRegistries#GAME_PORTAL_CONFIG} instead.
+     */
+    @Deprecated
+    SimpleRegistry<MapCodec<? extends GamePortalConfig>> REGISTRY = PlasmidRegistries.GAME_PORTAL_CONFIG;
+    Codec<GamePortalConfig> CODEC = PlasmidRegistries.GAME_PORTAL_CONFIG.getCodec().dispatchStable(GamePortalConfig::codec, Function.identity());
 
-    static void register(Identifier key, MapCodec<? extends GamePortalConfig> codec) {
-        REGISTRY.register(key, codec);
+    /**
+     * @deprecated Use {@link GamePortalConfigs#register(Identifier, MapCodec)} instead.
+     */
+    @Deprecated
+    static MapCodec<? extends GamePortalConfig> register(Identifier key, MapCodec<? extends GamePortalConfig> codec) {
+        return GamePortalConfigs.register(key, codec);
     }
 
     GamePortalBackend createBackend(MinecraftServer server, Identifier id);

--- a/src/main/java/xyz/nucleoid/plasmid/impl/portal/GamePortalConfig.java
+++ b/src/main/java/xyz/nucleoid/plasmid/impl/portal/GamePortalConfig.java
@@ -2,12 +2,12 @@ package xyz.nucleoid.plasmid.impl.portal;
 
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.MapCodec;
-import net.minecraft.registry.Registry;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.util.Identifier;
 import xyz.nucleoid.plasmid.api.game.config.CustomValuesConfig;
 import xyz.nucleoid.plasmid.api.portal.GamePortalConfigs;
 import xyz.nucleoid.plasmid.api.registry.PlasmidRegistries;
+import xyz.nucleoid.plasmid.api.util.TinyRegistry;
 
 import java.util.function.Function;
 
@@ -16,7 +16,7 @@ public interface GamePortalConfig {
      * @deprecated Use {@link PlasmidRegistries#GAME_PORTAL_CONFIG} instead.
      */
     @Deprecated
-    Registry<MapCodec<? extends GamePortalConfig>> REGISTRY = PlasmidRegistries.GAME_PORTAL_CONFIG;
+    TinyRegistry<MapCodec<? extends GamePortalConfig>> REGISTRY = new TinyRegistry.Fake<>(PlasmidRegistries.GAME_PORTAL_CONFIG);
     Codec<GamePortalConfig> CODEC = PlasmidRegistries.GAME_PORTAL_CONFIG.getCodec().dispatchStable(GamePortalConfig::codec, Function.identity());
 
     /**

--- a/src/main/java/xyz/nucleoid/plasmid/impl/portal/GamePortalConfig.java
+++ b/src/main/java/xyz/nucleoid/plasmid/impl/portal/GamePortalConfig.java
@@ -2,13 +2,12 @@ package xyz.nucleoid.plasmid.impl.portal;
 
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.MapCodec;
-import net.minecraft.registry.SimpleRegistry;
+import net.minecraft.registry.Registry;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.util.Identifier;
 import xyz.nucleoid.plasmid.api.game.config.CustomValuesConfig;
 import xyz.nucleoid.plasmid.api.portal.GamePortalConfigs;
 import xyz.nucleoid.plasmid.api.registry.PlasmidRegistries;
-import xyz.nucleoid.plasmid.api.util.TinyRegistry;
 
 import java.util.function.Function;
 
@@ -17,7 +16,7 @@ public interface GamePortalConfig {
      * @deprecated Use {@link PlasmidRegistries#GAME_PORTAL_CONFIG} instead.
      */
     @Deprecated
-    SimpleRegistry<MapCodec<? extends GamePortalConfig>> REGISTRY = PlasmidRegistries.GAME_PORTAL_CONFIG;
+    Registry<MapCodec<? extends GamePortalConfig>> REGISTRY = PlasmidRegistries.GAME_PORTAL_CONFIG;
     Codec<GamePortalConfig> CODEC = PlasmidRegistries.GAME_PORTAL_CONFIG.getCodec().dispatchStable(GamePortalConfig::codec, Function.identity());
 
     /**

--- a/src/main/java/xyz/nucleoid/plasmid/impl/portal/GamePortalInterface.java
+++ b/src/main/java/xyz/nucleoid/plasmid/impl/portal/GamePortalInterface.java
@@ -8,7 +8,7 @@ import org.jetbrains.annotations.Nullable;
 import xyz.nucleoid.plasmid.impl.Plasmid;
 
 public interface GamePortalInterface {
-    String NBT_KEY = Plasmid.ID + ":portal";
+    String NBT_KEY = Plasmid.id("portal").toString();
 
     boolean interactWithPortal(ServerPlayerEntity player);
 

--- a/src/main/java/xyz/nucleoid/plasmid/impl/portal/game/ConcurrentGamePortalConfig.java
+++ b/src/main/java/xyz/nucleoid/plasmid/impl/portal/game/ConcurrentGamePortalConfig.java
@@ -12,7 +12,7 @@ import xyz.nucleoid.plasmid.impl.portal.GamePortalConfig;
 
 public record ConcurrentGamePortalConfig(RegistryEntry<GameConfig<?>> game, CustomValuesConfig custom) implements GamePortalConfig {
     public static final MapCodec<ConcurrentGamePortalConfig> CODEC = RecordCodecBuilder.mapCodec(i -> i.group(
-            GameConfig.CODEC.fieldOf("game").forGetter(c -> c.game),
+            GameConfig.ENTRY_CODEC.fieldOf("game").forGetter(c -> c.game),
             CustomValuesConfig.CODEC.optionalFieldOf("custom", CustomValuesConfig.empty()).forGetter(c -> c.custom)
     ).apply(i, ConcurrentGamePortalConfig::new));
 

--- a/src/main/java/xyz/nucleoid/plasmid/impl/portal/game/LegacyOnDemandPortalConfig.java
+++ b/src/main/java/xyz/nucleoid/plasmid/impl/portal/game/LegacyOnDemandPortalConfig.java
@@ -12,7 +12,7 @@ import xyz.nucleoid.plasmid.impl.portal.GamePortalConfig;
 
 public record LegacyOnDemandPortalConfig(RegistryEntry<GameConfig<?>> game, CustomValuesConfig custom) implements GamePortalConfig {
     public static final MapCodec<LegacyOnDemandPortalConfig> CODEC = RecordCodecBuilder.mapCodec(i -> i.group(
-            GameConfig.CODEC.fieldOf("game").forGetter(c -> c.game),
+            GameConfig.ENTRY_CODEC.fieldOf("game").forGetter(c -> c.game),
             CustomValuesConfig.CODEC.optionalFieldOf("custom", CustomValuesConfig.empty()).forGetter(c -> c.custom)
     ).apply(i, LegacyOnDemandPortalConfig::new));
 

--- a/src/main/java/xyz/nucleoid/plasmid/impl/portal/game/NewGamePortalConfig.java
+++ b/src/main/java/xyz/nucleoid/plasmid/impl/portal/game/NewGamePortalConfig.java
@@ -12,7 +12,7 @@ import xyz.nucleoid.plasmid.impl.portal.GamePortalConfig;
 
 public record NewGamePortalConfig(RegistryEntry<GameConfig<?>> game, CustomValuesConfig custom) implements GamePortalConfig {
     public static final MapCodec<NewGamePortalConfig> CODEC = RecordCodecBuilder.mapCodec(i -> i.group(
-            GameConfig.CODEC.fieldOf("game").forGetter(c -> c.game),
+            GameConfig.ENTRY_CODEC.fieldOf("game").forGetter(c -> c.game),
             CustomValuesConfig.CODEC.optionalFieldOf("custom", CustomValuesConfig.empty()).forGetter(c -> c.custom)
     ).apply(i, NewGamePortalConfig::new));
 

--- a/src/main/java/xyz/nucleoid/plasmid/impl/portal/game/SingleGamePortalConfig.java
+++ b/src/main/java/xyz/nucleoid/plasmid/impl/portal/game/SingleGamePortalConfig.java
@@ -12,7 +12,7 @@ import xyz.nucleoid.plasmid.impl.portal.GamePortalConfig;
 
 public record SingleGamePortalConfig(RegistryEntry<GameConfig<?>> game, CustomValuesConfig custom) implements GamePortalConfig {
     public static final MapCodec<SingleGamePortalConfig> CODEC = RecordCodecBuilder.mapCodec(i -> i.group(
-            GameConfig.CODEC.fieldOf("game").forGetter(c -> c.game),
+            GameConfig.ENTRY_CODEC.fieldOf("game").forGetter(c -> c.game),
             CustomValuesConfig.CODEC.optionalFieldOf("custom", CustomValuesConfig.empty()).forGetter(c -> c.custom)
     ).apply(i, SingleGamePortalConfig::new));
 

--- a/src/main/java/xyz/nucleoid/plasmid/impl/portal/menu/GameMenuEntryConfig.java
+++ b/src/main/java/xyz/nucleoid/plasmid/impl/portal/menu/GameMenuEntryConfig.java
@@ -20,7 +20,7 @@ public record GameMenuEntryConfig(
         Optional<ItemStack> icon
 ) implements MenuEntryConfig {
     public static final MapCodec<GameMenuEntryConfig> CODEC = RecordCodecBuilder.mapCodec(i -> i.group(
-            GameConfig.CODEC.fieldOf("game").forGetter(GameMenuEntryConfig::game),
+            GameConfig.ENTRY_CODEC.fieldOf("game").forGetter(GameMenuEntryConfig::game),
             PlasmidCodecs.TEXT.optionalFieldOf("name").forGetter(GameMenuEntryConfig::name),
             MoreCodecs.listOrUnit(PlasmidCodecs.TEXT).optionalFieldOf("description").forGetter(GameMenuEntryConfig::description),
             MoreCodecs.ITEM_STACK.optionalFieldOf("icon").forGetter(GameMenuEntryConfig::icon)

--- a/src/main/java/xyz/nucleoid/plasmid/impl/portal/menu/MenuEntryConfig.java
+++ b/src/main/java/xyz/nucleoid/plasmid/impl/portal/menu/MenuEntryConfig.java
@@ -3,11 +3,11 @@ package xyz.nucleoid.plasmid.impl.portal.menu;
 import com.mojang.datafixers.util.Either;
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.MapCodec;
-import net.minecraft.registry.Registry;
 import net.minecraft.util.Identifier;
 import xyz.nucleoid.plasmid.api.game.config.GameConfig;
 import xyz.nucleoid.plasmid.api.portal.menu.MenuEntryConfigs;
 import xyz.nucleoid.plasmid.api.registry.PlasmidRegistries;
+import xyz.nucleoid.plasmid.api.util.TinyRegistry;
 
 import java.util.Optional;
 import java.util.function.Function;
@@ -17,7 +17,7 @@ public interface MenuEntryConfig {
      * @deprecated Use {@link PlasmidRegistries#MENU_ENTRY} instead.
      */
     @Deprecated
-    Registry<MapCodec<? extends MenuEntryConfig>> REGISTRY = PlasmidRegistries.MENU_ENTRY;
+    TinyRegistry<MapCodec<? extends MenuEntryConfig>> REGISTRY = new TinyRegistry.Fake<>(PlasmidRegistries.MENU_ENTRY);
 
     Codec<MenuEntryConfig> CODEC_OBJECT = PlasmidRegistries.MENU_ENTRY.getCodec().dispatchStable(MenuEntryConfig::codec, Function.identity());
     Codec<MenuEntryConfig> CODEC = Codec.either(GameConfig.ENTRY_CODEC, CODEC_OBJECT).xmap(either -> {

--- a/src/main/java/xyz/nucleoid/plasmid/impl/portal/menu/MenuEntryConfig.java
+++ b/src/main/java/xyz/nucleoid/plasmid/impl/portal/menu/MenuEntryConfig.java
@@ -3,11 +3,11 @@ package xyz.nucleoid.plasmid.impl.portal.menu;
 import com.mojang.datafixers.util.Either;
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.MapCodec;
+import net.minecraft.registry.Registry;
 import net.minecraft.util.Identifier;
 import xyz.nucleoid.plasmid.api.game.config.GameConfig;
 import xyz.nucleoid.plasmid.api.portal.menu.MenuEntryConfigs;
 import xyz.nucleoid.plasmid.api.registry.PlasmidRegistries;
-import xyz.nucleoid.plasmid.api.util.TinyRegistry;
 
 import java.util.Optional;
 import java.util.function.Function;
@@ -17,9 +17,9 @@ public interface MenuEntryConfig {
      * @deprecated Use {@link PlasmidRegistries#MENU_ENTRY} instead.
      */
     @Deprecated
-    TinyRegistry<MapCodec<? extends MenuEntryConfig>> REGISTRY = PlasmidRegistries.MENU_ENTRY;
+    Registry<MapCodec<? extends MenuEntryConfig>> REGISTRY = PlasmidRegistries.MENU_ENTRY;
 
-    Codec<MenuEntryConfig> CODEC_OBJECT = PlasmidRegistries.MENU_ENTRY.dispatchStable(MenuEntryConfig::codec, Function.identity());
+    Codec<MenuEntryConfig> CODEC_OBJECT = PlasmidRegistries.MENU_ENTRY.getCodec().dispatchStable(MenuEntryConfig::codec, Function.identity());
     Codec<MenuEntryConfig> CODEC = Codec.either(GameConfig.ENTRY_CODEC, CODEC_OBJECT).xmap(either -> {
         return either.map((game) -> new GameMenuEntryConfig(game, Optional.empty(), Optional.empty(), Optional.empty()), Function.identity());
     }, Either::right);

--- a/src/main/java/xyz/nucleoid/plasmid/impl/portal/menu/MenuEntryConfig.java
+++ b/src/main/java/xyz/nucleoid/plasmid/impl/portal/menu/MenuEntryConfig.java
@@ -5,21 +5,31 @@ import com.mojang.serialization.Codec;
 import com.mojang.serialization.MapCodec;
 import net.minecraft.util.Identifier;
 import xyz.nucleoid.plasmid.api.game.config.GameConfig;
+import xyz.nucleoid.plasmid.api.portal.menu.MenuEntryConfigs;
+import xyz.nucleoid.plasmid.api.registry.PlasmidRegistries;
 import xyz.nucleoid.plasmid.api.util.TinyRegistry;
 
 import java.util.Optional;
 import java.util.function.Function;
 
 public interface MenuEntryConfig {
-    TinyRegistry<MapCodec<? extends MenuEntryConfig>> REGISTRY = TinyRegistry.create();
+    /**
+     * @deprecated Use {@link PlasmidRegistries#MENU_ENTRY} instead.
+     */
+    @Deprecated
+    TinyRegistry<MapCodec<? extends MenuEntryConfig>> REGISTRY = PlasmidRegistries.MENU_ENTRY;
 
-    Codec<MenuEntryConfig> CODEC_OBJECT = REGISTRY.dispatchStable(MenuEntryConfig::codec, Function.identity());
-    Codec<MenuEntryConfig> CODEC = Codec.either(GameConfig.CODEC, CODEC_OBJECT).xmap(either -> {
+    Codec<MenuEntryConfig> CODEC_OBJECT = PlasmidRegistries.MENU_ENTRY.dispatchStable(MenuEntryConfig::codec, Function.identity());
+    Codec<MenuEntryConfig> CODEC = Codec.either(GameConfig.ENTRY_CODEC, CODEC_OBJECT).xmap(either -> {
         return either.map((game) -> new GameMenuEntryConfig(game, Optional.empty(), Optional.empty(), Optional.empty()), Function.identity());
     }, Either::right);
 
-    static void register(Identifier key, MapCodec<? extends MenuEntryConfig> codec) {
-        REGISTRY.register(key, codec);
+    /**
+     * @deprecated Use {@link MenuEntryConfigs#register(Identifier, MapCodec)} instead.
+     */
+    @Deprecated
+    static MapCodec<? extends MenuEntryConfig> register(Identifier key, MapCodec<? extends MenuEntryConfig> codec) {
+        return MenuEntryConfigs.register(key, codec);
     }
 
     MenuEntry createEntry();

--- a/src/main/java/xyz/nucleoid/plasmid/impl/portal/menu/MenuPortalConfig.java
+++ b/src/main/java/xyz/nucleoid/plasmid/impl/portal/menu/MenuPortalConfig.java
@@ -62,13 +62,13 @@ public record MenuPortalConfig(
                         Optional<ItemStack> icon) {
 
         static final Codec<Entry> CODEC_OBJECT = RecordCodecBuilder.create(i -> i.group(
-                GameConfig.CODEC.fieldOf("game").forGetter(entry -> entry.game),
+                GameConfig.ENTRY_CODEC.fieldOf("game").forGetter(entry -> entry.game),
                 PlasmidCodecs.TEXT.optionalFieldOf("name").forGetter(Entry::name),
                 MoreCodecs.listOrUnit(PlasmidCodecs.TEXT).optionalFieldOf("description").forGetter(Entry::description),
                 MoreCodecs.ITEM_STACK.optionalFieldOf("icon").forGetter(Entry::icon)
         ).apply(i, Entry::new));
 
-        public static final Codec<Entry> CODEC = Codec.either(GameConfig.CODEC, CODEC_OBJECT)
+        public static final Codec<Entry> CODEC = Codec.either(GameConfig.ENTRY_CODEC, CODEC_OBJECT)
                 .xmap(either -> either.map((game) -> new Entry(game, Optional.empty(), Optional.empty(), Optional.empty()), Function.identity()), Either::right);
     }
 }

--- a/src/main/java/xyz/nucleoid/plasmid/mixin/SimpleRegistryMixin.java
+++ b/src/main/java/xyz/nucleoid/plasmid/mixin/SimpleRegistryMixin.java
@@ -5,43 +5,44 @@ import net.minecraft.registry.RegistryKey;
 import net.minecraft.registry.SimpleRegistry;
 import net.minecraft.registry.entry.RegistryEntry;
 import net.minecraft.registry.entry.RegistryEntryInfo;
-import net.minecraft.util.Identifier;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
-import xyz.nucleoid.plasmid.api.game.GameType;
+import xyz.nucleoid.plasmid.api.game.GameTypes;
 import xyz.nucleoid.plasmid.api.game.config.CustomValuesConfig;
 import xyz.nucleoid.plasmid.api.game.config.GameConfig;
-import xyz.nucleoid.plasmid.api.game.config.GameConfigs;
+import xyz.nucleoid.plasmid.api.registry.PlasmidRegistryKeys;
 import xyz.nucleoid.plasmid.impl.Plasmid;
 import xyz.nucleoid.plasmid.impl.PlasmidConfig;
 
 import java.util.Map;
-import java.util.stream.Collectors;
 
 @Deprecated
 @Mixin(SimpleRegistry.class)
 public abstract class SimpleRegistryMixin {
-    @Shadow public abstract RegistryKey<? extends Registry<Object>> getKey();
+    @Shadow
+    public abstract RegistryKey<? extends Registry<Object>> getKey();
 
-    @Shadow @Final private Map<RegistryKey<Object>, RegistryEntry.Reference<Object>> keyToEntry;
+    @Shadow
+    @Final
+    private Map<RegistryKey<Object>, RegistryEntry.Reference<Object>> keyToEntry;
 
-    @Shadow public abstract RegistryEntry.Reference<Object> add(RegistryKey<Object> key, Object value, RegistryEntryInfo info);
+    @Shadow
+    public abstract RegistryEntry.Reference<Object> add(RegistryKey<Object> key, Object value, RegistryEntryInfo info);
 
     @Inject(method = "freeze", at = @At("HEAD"))
     private void maybeRegisterInvalidConfigs(CallbackInfoReturnable<Registry<Object>> cir) {
-        if (!PlasmidConfig.get().ignoreInvalidGames() || !this.getKey().equals(GameConfigs.REGISTRY_KEY)) {
+        if (!PlasmidConfig.get().ignoreInvalidGames() || !this.getKey().equals(PlasmidRegistryKeys.GAME_CONFIG)) {
             return;
         }
-        var type = (GameType<Object>) GameType.REGISTRY.get(Identifier.of(Plasmid.ID, "invalid"));
 
         var keys = this.keyToEntry.entrySet().stream().filter((entry) -> !entry.getValue().hasKeyAndValue()).toList();
         for (var key : keys) {
             Plasmid.LOGGER.error("Something depends on non-existing game config '{}'!", key.getKey().getValue());
-            this.add(key.getKey(), new GameConfig<>(type, null, null, null, null, CustomValuesConfig.empty(), key.getKey().getValue().toString()),RegistryEntryInfo.DEFAULT);
+            this.add(key.getKey(), new GameConfig<>(GameTypes.INVALID, null, null, null, null, CustomValuesConfig.empty(), key.getKey().getValue().toString()), RegistryEntryInfo.DEFAULT);
         }
     }
 }

--- a/src/testmod/java/xyz/nucleoid/plasmid/test/TestGame.java
+++ b/src/testmod/java/xyz/nucleoid/plasmid/test/TestGame.java
@@ -55,7 +55,7 @@ import java.util.List;
 public final class TestGame {
     private static final BlockState BUTTON = Blocks.OAK_BUTTON.getDefaultState().with(ButtonBlock.FACE, BlockFace.FLOOR);
     private static final List<Method> WOOD_TYPE_BLOCK_FIELDS = Arrays.stream(WoodType.class.getMethods()).filter(x -> x.getReturnType() == Block.class).toList();
-    private static final StatisticKey<Double> TEST_KEY = StatisticKey.doubleKey(Identifier.of(Plasmid.ID, "test"));
+    private static final StatisticKey<Double> TEST_KEY = StatisticKey.doubleKey(Plasmid.id("test"));
 
     private static final GameTeam TEAM = new GameTeam(
             new GameTeamKey("players"),

--- a/src/testmod/java/xyz/nucleoid/plasmid/test/TestGameWithResourcePack.java
+++ b/src/testmod/java/xyz/nucleoid/plasmid/test/TestGameWithResourcePack.java
@@ -34,7 +34,7 @@ import xyz.nucleoid.stimuli.event.EventResult;
 import xyz.nucleoid.stimuli.event.player.PlayerDeathEvent;
 
 public final class TestGameWithResourcePack {
-    private static final StatisticKey<Double> TEST_KEY = StatisticKey.doubleKey(Identifier.of(Plasmid.ID, "test_rp"));
+    private static final StatisticKey<Double> TEST_KEY = StatisticKey.doubleKey(Plasmid.id("test_rp"));
 
     private static final GameTeam TEAM = new GameTeam(
             new GameTeamKey("players"),

--- a/src/testmod/java/xyz/nucleoid/plasmid/test/TestInitializer.java
+++ b/src/testmod/java/xyz/nucleoid/plasmid/test/TestInitializer.java
@@ -17,7 +17,7 @@ import net.minecraft.registry.RegistryKey;
 import net.minecraft.registry.RegistryKeys;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.Unit;
-import xyz.nucleoid.plasmid.api.game.GameType;
+import xyz.nucleoid.plasmid.api.game.GameTypes;
 import xyz.nucleoid.plasmid.api.game.common.GameResourcePack;
 
 import java.util.Optional;
@@ -46,11 +46,11 @@ public class TestInitializer implements ModInitializer {
 
     @Override
     public void onInitialize() {
-        GameType.register(Identifier.of(ID, "test"), TestConfig.CODEC, TestGame::open);
-        GameType.register(Identifier.of(ID, "persistent"), MapCodec.unit(Unit.INSTANCE), PersistentGame::open);
-        GameType.register(Identifier.of(ID, "no_join"), TestConfig.CODEC, PlayerlessGame::open);
-        GameType.register(Identifier.of(ID, "test_rp"), TestConfig.CODEC, TestGameWithResourcePack::open);
-        GameType.register(Identifier.of(ID, "jank"), TestConfig.CODEC, JankGame::open);
+        GameTypes.register(Identifier.of(ID, "test"), TestConfig.CODEC, TestGame::open);
+        GameTypes.register(Identifier.of(ID, "persistent"), MapCodec.unit(Unit.INSTANCE), PersistentGame::open);
+        GameTypes.register(Identifier.of(ID, "no_join"), TestConfig.CODEC, PlayerlessGame::open);
+        GameTypes.register(Identifier.of(ID, "test_rp"), TestConfig.CODEC, TestGameWithResourcePack::open);
+        GameTypes.register(Identifier.of(ID, "jank"), TestConfig.CODEC, JankGame::open);
         Registry.register(Registries.BLOCK, TEST_BLOCK_KEY, TEST_BLOCK);
         Registry.register(Registries.ITEM, TEST_ITEM_KEY, TEST_ITEM);
 


### PR DESCRIPTION
This centralizes and exposes our registries (and values registred by Plasmid) in the API.

This is an effort to allow for further enhancements down the road, such as easier data generation, reusability and sticking to vanilla closer than before. This also set an example as to how mini-games mods should be correctly registering their content.

This PR effectively:
- Adds `PlasmidRegistries` and `PlasmidRegistryKeys` classes, containing registries and registry keys added by Plasmid.
  - Existing constants are marked as deprecated, until the next major version arrives and erases them
- Alleviates the main `Plasmid` class by registering content in dedicated API classes
  - This also exposes registered values, allowing for usages like data generation and using tags
- Deprecates existing calls to registering methods, that were located inside the registered object classes themselves
  - These methods now redirect to newer methods located in the API classes mentionned above 