### PR TITLE
Allow constructing template chunk generators without a server instance

### DIFF
--- a/src/main/java/xyz/nucleoid/plasmid/api/game/world/generator/GameChunkGenerator.java
+++ b/src/main/java/xyz/nucleoid/plasmid/api/game/world/generator/GameChunkGenerator.java
@@ -2,6 +2,7 @@ package xyz.nucleoid.plasmid.api.game.world.generator;
 
 import net.minecraft.registry.RegistryKey;
 import net.minecraft.registry.RegistryKeys;
+import net.minecraft.registry.RegistryWrapper;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.ChunkRegion;
@@ -32,9 +33,12 @@ public abstract class GameChunkGenerator extends TransientChunkGenerator {
         this(createBiomeSource(server, BiomeKeys.THE_VOID));
     }
 
+    protected static FixedBiomeSource createBiomeSource(RegistryWrapper.WrapperLookup registries, RegistryKey<Biome> biome) {
+        return new FixedBiomeSource(registries.getOrThrow(RegistryKeys.BIOME).getOrThrow(biome));
+    }
+
     protected static FixedBiomeSource createBiomeSource(MinecraftServer server, RegistryKey<Biome> biome) {
-        var registryManager = server.getRegistryManager();
-        return new FixedBiomeSource(registryManager.getOrThrow(RegistryKeys.BIOME).getOrThrow(biome));
+        return createBiomeSource(server.getRegistryManager(), biome);
     }
 
     @Override

--- a/src/main/java/xyz/nucleoid/plasmid/api/game/world/generator/TemplateChunkGenerator.java
+++ b/src/main/java/xyz/nucleoid/plasmid/api/game/world/generator/TemplateChunkGenerator.java
@@ -3,6 +3,7 @@ package xyz.nucleoid.plasmid.api.game.world.generator;
 import net.minecraft.block.BlockState;
 import net.minecraft.registry.DynamicRegistryManager;
 import net.minecraft.registry.RegistryKey;
+import net.minecraft.registry.RegistryWrapper;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.structure.StructureTemplateManager;
 import net.minecraft.util.math.BlockPos;
@@ -30,11 +31,15 @@ public class TemplateChunkGenerator extends GameChunkGenerator {
     private final MapTemplate template;
     private final BlockBounds worldBounds;
 
-    public TemplateChunkGenerator(MinecraftServer server, MapTemplate template) {
-        super(createBiomeSource(server, template.getBiome()));
+    public TemplateChunkGenerator(RegistryWrapper.WrapperLookup registries, MapTemplate template) {
+        super(createBiomeSource(registries, template.getBiome()));
 
         this.template = template;
         this.worldBounds = template.getBounds();
+    }
+
+    public TemplateChunkGenerator(MinecraftServer server, MapTemplate template) {
+        this(server.getRegistryManager(), template);
     }
 
     @Override


### PR DESCRIPTION
Data generators are [serverless](https://miro.medium.com/v2/format:webp/1*DgdXbb-mdbrKE_J9zsSQXw.jpeg) infrastructure, so having a `TemplateChunkGenerator` constructor that uses a `RegistryWrapper.WrapperLookup` parameter would be useful.