### PR TITLE
implement toString in ManagedGameSpace

### DIFF
--- a/src/main/java/xyz/nucleoid/plasmid/impl/game/manager/ManagedGameSpace.java
+++ b/src/main/java/xyz/nucleoid/plasmid/impl/game/manager/ManagedGameSpace.java
@@ -200,6 +200,11 @@ public final class ManagedGameSpace implements GameSpace {
         return this.state;
     }
 
+    @Override
+    public String toString() {
+        return this.metadata.toString();
+    }
+
     JoinOfferResult offerPlayers(LocalJoinOffer offer) {
         if (this.closed) {
             return offer.reject(GameTexts.Join.gameClosed());


### PR DESCRIPTION
Implement `toString` in `ManagedGameSpace` by redirecting to the metadata. This was done to add more information to [`GameAttachmentHolder#getAttachmentOrThrow`](https://github.com/NucleoidMC/plasmid/blob/807aa61fcebd8602d872c854dd4fafd16d8c4470/src/main/java/xyz/nucleoid/plasmid/api/game/GameAttachmentHolder.java#L12). The other fields don't seem important enough to add, `closed` maybe.