### PR TITLE
Fix: Always reload player inventory after closing waiting lobby ui

### DIFF
--- a/src/main/java/xyz/nucleoid/plasmid/api/game/common/GameWaitingLobby.java
+++ b/src/main/java/xyz/nucleoid/plasmid/api/game/common/GameWaitingLobby.java
@@ -217,8 +217,9 @@ public final class GameWaitingLobby {
 
                     if (gui instanceof WaitingLobbyUi) {
                         player.onHandledScreenClosed();
-                        PolymerUtils.reloadInventory(player);
                     }
+
+                    PolymerUtils.reloadInventory(player);
                 }
             }
         }


### PR DESCRIPTION
This fixes a regression introduced by 3e4f9961c62d43b9e05ea9e29aacc9a04c937f36 where games that added to the waiting lobby ui didn't have their items removed once the ui is closed. Fixes nucleoidmc/skywars#57 and other games that had this behaviour