### PR TITLE
Feature: Add Private Games

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.0-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/src/main/java/xyz/nucleoid/plasmid/api/game/GameSpace.java
+++ b/src/main/java/xyz/nucleoid/plasmid/api/game/GameSpace.java
@@ -10,6 +10,7 @@ import xyz.nucleoid.plasmid.api.game.event.GamePlayerEvents;
 import xyz.nucleoid.plasmid.api.game.level.GameSpaceLevels;
 import xyz.nucleoid.plasmid.api.util.PlayerRef;
 
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.function.Consumer;
@@ -86,22 +87,22 @@ public interface GameSpace extends GameAttachmentHolder {
 
     /**
      * Gets all player filters in this {@link GameSpace}.
-     * @return A {@link Map<UUID, Predicate<PlayerRef>>} containing all player filters.
+     * @return A {@link List<Predicate<PlayerRef>>} containing all player filters.
      */
-    Map<UUID, Predicate<PlayerRef>> getPlayerFilters();
+    List<Predicate<PlayerRef>> getPlayerFilters();
 
     /**
      * Adds a player filter that gets applied whenever a player joins this {@link GameSpace}.
      * Applied before any game activity specific filtering.
      * @param filter A predicate with a single {@link PlayerRef} argument that returns true if the player is allowed or false otherwise.
-     * @return A {@link UUID} that identifies this filter.
+     * @return The player filter that was added.
      */
-    UUID addPlayerFilter(Predicate<PlayerRef> filter);
+    Predicate<PlayerRef> addPlayerFilter(Predicate<PlayerRef> filter);
     /**
      * Remove a player filter from the list of filters.
-     * @param filterIdentity The {@link UUID} that identifies this filter.
+     * @param filter The player filter.
      */
-    void removePlayerFilter(UUID filterIdentity);
+    void removePlayerFilter(Predicate<PlayerRef> filter);
     /**
      * Tests if the player is allowed to join based on the applied player filters
      * @param player The {@link PlayerRef} to test for

--- a/src/main/java/xyz/nucleoid/plasmid/api/game/GameSpace.java
+++ b/src/main/java/xyz/nucleoid/plasmid/api/game/GameSpace.java
@@ -12,6 +12,7 @@ import xyz.nucleoid.plasmid.api.util.PlayerRef;
 
 import java.util.ArrayList;
 import java.util.function.Consumer;
+import java.util.function.Predicate;
 
 /**
  * Represents an instance of a game, and the "space" within which it occurs.
@@ -83,29 +84,24 @@ public interface GameSpace extends GameAttachmentHolder {
     GameSpacePlayers getPlayers();
 
     /**
-     * Returns all {@link ServerPlayer}s in this {@link GameSpace}'s whitelist.
-     * @return a {@link ArrayList<PlayerRef>} that contains all {@link ServerPlayer}s in the {@link GameSpace} whitelist
+     * Gets all player filters in this {@link GameSpace}.
+     * @return An {@link ArrayList<Predicate<PlayerRef>>} containing all player filters.
      */
-    ArrayList<PlayerRef> getWhitelist();
+    ArrayList<Predicate<PlayerRef>> getPlayerFilters();
 
     /**
-     * Returns if the {@link PlayerRef} is in this {@link GameSpace}'s whitelist.
-     * @param playerRef The player to check
-     * @return true if the player is in the whitelist, false otherwise
+     * Adds a player filter that gets applied whenever a player joins this {@link GameSpace}.
+     * Applied before any game activity specific filtering.
+     * @param filter A predicate with a single {@link PlayerRef} argument that returns true if the player is allowed or false otherwise.
      */
-    boolean isPlayerInWhitelist(PlayerRef playerRef);
+    void addPlayerFilter(Predicate<PlayerRef> filter);
 
     /**
-     * Adds a {@link PlayerRef} to the whitelist
-     * @param playerRef The player to add to the whitelist
+     * Tests if the player is allowed to join based on the applied player filters
+     * @param player The {@link PlayerRef} to test for
+     * @return true if the player is allowed, false otherwise.
      */
-    void addPlayerToWhitelist(PlayerRef playerRef);
-
-    /**
-     * Removes the {@link PlayerRef} from the whitelist
-     * @param playerRef The player to remove from the whitelist
-     */
-    void removePlayerFromWhitelist(PlayerRef playerRef);
+    boolean isPlayerAllowed(PlayerRef player);
 
     /**
      * Returns the manager for all attached {@link ServerLevel} instances to this {@link GameSpace}.

--- a/src/main/java/xyz/nucleoid/plasmid/api/game/GameSpace.java
+++ b/src/main/java/xyz/nucleoid/plasmid/api/game/GameSpace.java
@@ -10,7 +10,8 @@ import xyz.nucleoid.plasmid.api.game.event.GamePlayerEvents;
 import xyz.nucleoid.plasmid.api.game.level.GameSpaceLevels;
 import xyz.nucleoid.plasmid.api.util.PlayerRef;
 
-import java.util.ArrayList;
+import java.util.Map;
+import java.util.UUID;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
 
@@ -85,17 +86,22 @@ public interface GameSpace extends GameAttachmentHolder {
 
     /**
      * Gets all player filters in this {@link GameSpace}.
-     * @return An {@link ArrayList<Predicate<PlayerRef>>} containing all player filters.
+     * @return A {@link Map<UUID, Predicate<PlayerRef>>} containing all player filters.
      */
-    ArrayList<Predicate<PlayerRef>> getPlayerFilters();
+    Map<UUID, Predicate<PlayerRef>> getPlayerFilters();
 
     /**
      * Adds a player filter that gets applied whenever a player joins this {@link GameSpace}.
      * Applied before any game activity specific filtering.
      * @param filter A predicate with a single {@link PlayerRef} argument that returns true if the player is allowed or false otherwise.
+     * @return A {@link UUID} that identifies this filter.
      */
-    void addPlayerFilter(Predicate<PlayerRef> filter);
-
+    UUID addPlayerFilter(Predicate<PlayerRef> filter);
+    /**
+     * Remove a player filter from the list of filters.
+     * @param filterIdentity The {@link UUID} that identifies this filter.
+     */
+    void removePlayerFilter(UUID filterIdentity);
     /**
      * Tests if the player is allowed to join based on the applied player filters
      * @param player The {@link PlayerRef} to test for

--- a/src/main/java/xyz/nucleoid/plasmid/api/game/GameSpace.java
+++ b/src/main/java/xyz/nucleoid/plasmid/api/game/GameSpace.java
@@ -8,7 +8,9 @@ import xyz.nucleoid.plasmid.api.game.player.PlayerSet;
 import xyz.nucleoid.plasmid.api.game.event.GameActivityEvents;
 import xyz.nucleoid.plasmid.api.game.event.GamePlayerEvents;
 import xyz.nucleoid.plasmid.api.game.level.GameSpaceLevels;
+import xyz.nucleoid.plasmid.api.util.PlayerRef;
 
+import java.util.ArrayList;
 import java.util.function.Consumer;
 
 /**
@@ -79,6 +81,31 @@ public interface GameSpace extends GameAttachmentHolder {
      * @return a {@link PlayerSet} that contains all {@link ServerPlayer}s in this {@link GameSpace}
      */
     GameSpacePlayers getPlayers();
+
+    /**
+     * Returns all {@link ServerPlayer}s in this {@link GameSpace}'s whitelist.
+     * @return a {@link ArrayList<PlayerRef>} that contains all {@link ServerPlayer}s in the {@link GameSpace} whitelist
+     */
+    ArrayList<PlayerRef> getWhitelist();
+
+    /**
+     * Returns if the {@link PlayerRef} is in this {@link GameSpace}'s whitelist.
+     * @param playerRef The player to check
+     * @return true if the player is in the whitelist, false otherwise
+     */
+    boolean isPlayerInWhitelist(PlayerRef playerRef);
+
+    /**
+     * Adds a {@link PlayerRef} to the whitelist
+     * @param playerRef The player to add to the whitelist
+     */
+    void addPlayerToWhitelist(PlayerRef playerRef);
+
+    /**
+     * Removes the {@link PlayerRef} from the whitelist
+     * @param playerRef The player to remove from the whitelist
+     */
+    void removePlayerFromWhitelist(PlayerRef playerRef);
 
     /**
      * Returns the manager for all attached {@link ServerLevel} instances to this {@link GameSpace}.

--- a/src/main/java/xyz/nucleoid/plasmid/api/game/common/GameWaitingLobby.java
+++ b/src/main/java/xyz/nucleoid/plasmid/api/game/common/GameWaitingLobby.java
@@ -17,6 +17,7 @@ import xyz.nucleoid.plasmid.api.game.player.JoinOfferResult;
 import xyz.nucleoid.plasmid.api.game.player.PlayerSet;
 import xyz.nucleoid.plasmid.api.game.rule.GameRuleType;
 import xyz.nucleoid.plasmid.api.game.common.widget.SidebarWidget;
+import xyz.nucleoid.plasmid.api.util.PlayerRef;
 import xyz.nucleoid.plasmid.impl.game.common.ui.WaitingLobbyUi;
 import xyz.nucleoid.plasmid.impl.game.common.ui.element.LeaveGameWaitingLobbyUiElement;
 import xyz.nucleoid.plasmid.impl.game.common.ui.element.ReadyGameWaitingLobbyUiElement;
@@ -336,7 +337,6 @@ public final class GameWaitingLobby {
         if (this.startRequested) {
             return START_REQUESTED_COUNTDOWN;
         }
-
         if (this.gameSpace.getPlayers().participants().size() >= this.playerConfig.minPlayers()) {
             double playersNeededToStart = Math.ceil((double) this.gameSpace.getPlayers().participants().size() / 2);
             if (playersNeededToStart <= this.playerVotes.size()) {
@@ -435,6 +435,17 @@ public final class GameWaitingLobby {
         var server = this.gameSpace.getServer();
         if (count >= server.getPlayerCount()) {
             return true;
+        }
+
+        // if the game is private and all players are in the whitelist
+        if (!this.gameSpace.getWhitelist().isEmpty()) {
+            ArrayList<PlayerRef> remainingPlayers = new ArrayList<>(this.gameSpace.getWhitelist());
+            for (ServerPlayer player : this.gameSpace.getPlayers()) {
+                remainingPlayers.remove(PlayerRef.of(player));
+            }
+            if (remainingPlayers.isEmpty()) {
+                return true;
+            }
         }
 
         // if there are no players outside of a game on the server

--- a/src/main/java/xyz/nucleoid/plasmid/api/game/common/GameWaitingLobby.java
+++ b/src/main/java/xyz/nucleoid/plasmid/api/game/common/GameWaitingLobby.java
@@ -437,17 +437,6 @@ public final class GameWaitingLobby {
             return true;
         }
 
-        // if the game is private and all players are in the whitelist
-        if (!this.gameSpace.getWhitelist().isEmpty()) {
-            ArrayList<PlayerRef> remainingPlayers = new ArrayList<>(this.gameSpace.getWhitelist());
-            for (ServerPlayer player : this.gameSpace.getPlayers()) {
-                remainingPlayers.remove(PlayerRef.of(player));
-            }
-            if (remainingPlayers.isEmpty()) {
-                return true;
-            }
-        }
-
         // if there are no players outside of a game on the server
         for (var world : server.getAllLevels()) {
             if (hasActivePlayer(world) && !GameSpaceManagerImpl.get().hasGame(world)) {

--- a/src/main/java/xyz/nucleoid/plasmid/api/game/player/GamePlayerJoiner.java
+++ b/src/main/java/xyz/nucleoid/plasmid/api/game/player/GamePlayerJoiner.java
@@ -1,8 +1,11 @@
 package xyz.nucleoid.plasmid.api.game.player;
 
 import it.unimi.dsi.fastutil.objects.ReferenceOpenHashSet;
+import net.minecraft.network.chat.Component;
+import net.minecraft.server.level.ServerPlayer;
 import xyz.nucleoid.plasmid.api.event.GameEvents;
 import xyz.nucleoid.plasmid.api.game.*;
+import xyz.nucleoid.plasmid.api.util.PlayerRef;
 import xyz.nucleoid.plasmid.impl.Plasmid;
 
 import java.util.Collection;
@@ -34,6 +37,19 @@ public final class GamePlayerJoiner {
     }
 
     private static GameResult tryJoinAll(Collection<ServerPlayer> players, GameSpace gameSpace, JoinIntent intent) {
+        boolean playersInWhitelist = true;
+        if (!gameSpace.getWhitelist().isEmpty()) {
+            for (ServerPlayer player : players) {
+                if (!gameSpace.isPlayerInWhitelist(PlayerRef.of(player))) {
+                    playersInWhitelist = false;
+                    break;
+                }
+            }
+        }
+
+        if (!playersInWhitelist) {
+            return GameResult.error(Component.translatable("text.plasmid.game.join.party.error.private"));
+        }
         return gameSpace.getPlayers().offer(players, intent);
     }
 

--- a/src/main/java/xyz/nucleoid/plasmid/api/game/player/GamePlayerJoiner.java
+++ b/src/main/java/xyz/nucleoid/plasmid/api/game/player/GamePlayerJoiner.java
@@ -37,18 +37,16 @@ public final class GamePlayerJoiner {
     }
 
     private static GameResult tryJoinAll(Collection<ServerPlayer> players, GameSpace gameSpace, JoinIntent intent) {
-        boolean playersInWhitelist = true;
-        if (!gameSpace.getWhitelist().isEmpty()) {
-            for (ServerPlayer player : players) {
-                if (!gameSpace.isPlayerInWhitelist(PlayerRef.of(player))) {
-                    playersInWhitelist = false;
-                    break;
-                }
+        boolean playersAreAllowed = true;
+        for (ServerPlayer player : players) {
+            if (!gameSpace.isPlayerAllowed(PlayerRef.of(player))) {
+                playersAreAllowed = false;
+                break;
             }
         }
 
-        if (!playersInWhitelist) {
-            return GameResult.error(Component.translatable("text.plasmid.game.join.party.error.private"));
+        if (!playersAreAllowed) {
+            return GameResult.error(Component.translatable("text.plasmid.game.join.party.error.not_allowed"));
         }
         return gameSpace.getPlayers().offer(players, intent);
     }

--- a/src/main/java/xyz/nucleoid/plasmid/impl/command/GameCommand.java
+++ b/src/main/java/xyz/nucleoid/plasmid/impl/command/GameCommand.java
@@ -205,10 +205,9 @@ public final class GameCommand {
             }
         } else if (player != null) {
             tryJoinGame(player, gameSpace, JoinIntent.PLAY);
-            // only send messages to players in whitelist if its active, otherwise send to all
+            // only send messages to players that are allowed to join
             players.getPlayers().stream().
-                    filter((plr -> gameSpace.getWhitelist().isEmpty()
-                            || gameSpace.isPlayerInWhitelist(PlayerRef.of(plr))))
+                    filter((plr) -> gameSpace.isPlayerAllowed(PlayerRef.of(plr)))
                     .forEach((plr -> plr.sendSystemMessage(message, false)));
         }
     }

--- a/src/main/java/xyz/nucleoid/plasmid/impl/command/GameCommand.java
+++ b/src/main/java/xyz/nucleoid/plasmid/impl/command/GameCommand.java
@@ -19,6 +19,7 @@ import net.minecraft.network.chat.MutableComponent;
 import net.minecraft.server.level.ServerPlayer;
 import org.slf4j.Logger;
 import xyz.nucleoid.plasmid.api.registry.PlasmidRegistryKeys;
+import xyz.nucleoid.plasmid.api.util.PlayerRef;
 import xyz.nucleoid.plasmid.impl.Plasmid;
 import xyz.nucleoid.plasmid.impl.command.argument.GameConfigArgument;
 import xyz.nucleoid.plasmid.impl.command.argument.GameSpaceArgument;
@@ -192,9 +193,8 @@ public final class GameCommand {
         var players = source.getServer().getPlayerList();
 
         var message = test ? GameComponents.Broadcast.gameOpenedTesting(source, gameSpace) : GameComponents.Broadcast.gameOpened(source, gameSpace);
-        players.broadcastSystemMessage(message, false);
-
         if (test) {
+            players.broadcastSystemMessage(message, false);
             joinAllPlayersToGame(source, gameSpace);
 
             var startResult = gameSpace.requestStart();
@@ -205,6 +205,11 @@ public final class GameCommand {
             }
         } else if (player != null) {
             tryJoinGame(player, gameSpace, JoinIntent.PLAY);
+            // only send messages to players in whitelist if its active, otherwise send to all
+            players.getPlayers().stream().
+                    filter((plr -> gameSpace.getWhitelist().isEmpty()
+                            || gameSpace.isPlayerInWhitelist(PlayerRef.of(plr))))
+                    .forEach((plr -> plr.sendSystemMessage(message, false)));
         }
     }
 

--- a/src/main/java/xyz/nucleoid/plasmid/impl/command/argument/GameSpaceArgument.java
+++ b/src/main/java/xyz/nucleoid/plasmid/impl/command/argument/GameSpaceArgument.java
@@ -11,6 +11,7 @@ import net.minecraft.commands.arguments.IdentifierArgument;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.Identifier;
 import xyz.nucleoid.plasmid.api.game.GameSpace;
+import xyz.nucleoid.plasmid.api.util.PlayerRef;
 import xyz.nucleoid.plasmid.impl.game.manager.GameSpaceManagerImpl;
 
 public final class GameSpaceArgument {
@@ -22,7 +23,9 @@ public final class GameSpaceArgument {
                     var gameSpaceManager = GameSpaceManagerImpl.get();
 
                     return SharedSuggestionProvider.suggestResource(
-                            gameSpaceManager.getOpenGameSpaces().stream().map(space -> space.getMetadata().userId()),
+                            gameSpaceManager.getOpenGameSpaces().stream()
+                                    .filter((space -> space.getWhitelist().isEmpty() || space.isPlayerInWhitelist(PlayerRef.of(context.getSource().getPlayer()))))
+                                    .map(space -> space.getMetadata().userId()),
                             builder
                     );
                 });

--- a/src/main/java/xyz/nucleoid/plasmid/impl/command/argument/GameSpaceArgument.java
+++ b/src/main/java/xyz/nucleoid/plasmid/impl/command/argument/GameSpaceArgument.java
@@ -24,7 +24,7 @@ public final class GameSpaceArgument {
 
                     return SharedSuggestionProvider.suggestResource(
                             gameSpaceManager.getOpenGameSpaces().stream()
-                                    .filter((space -> space.getWhitelist().isEmpty() || space.isPlayerInWhitelist(PlayerRef.of(context.getSource().getPlayer()))))
+                                    .filter((space -> space.isPlayerAllowed(PlayerRef.of(context.getSource().getPlayer()))))
                                     .map(space -> space.getMetadata().userId()),
                             builder
                     );

--- a/src/main/java/xyz/nucleoid/plasmid/impl/command/ui/GameJoinUi.java
+++ b/src/main/java/xyz/nucleoid/plasmid/impl/command/ui/GameJoinUi.java
@@ -61,11 +61,12 @@ public class GameJoinUi extends SimpleGui {
     }
 
     private void updateUi() {
+        PlayerRef playerRef = PlayerRef.of(this.player);
         int i = 0;
         int gameI = 0;
 
         var games = new ArrayList<>(GameSpaceManagerImpl.get().getOpenGameSpaces());
-        games.removeIf((gameSpace -> !gameSpace.isPlayerAllowed(PlayerRef.of(this.player))));
+        games.removeIf((gameSpace -> !gameSpace.isPlayerAllowed(playerRef)));
         games.sort(Comparator.comparingInt(space -> -space.getPlayers().size()));
 
         int limit = this.size;

--- a/src/main/java/xyz/nucleoid/plasmid/impl/command/ui/GameJoinUi.java
+++ b/src/main/java/xyz/nucleoid/plasmid/impl/command/ui/GameJoinUi.java
@@ -65,7 +65,7 @@ public class GameJoinUi extends SimpleGui {
         int gameI = 0;
 
         var games = new ArrayList<>(GameSpaceManagerImpl.get().getOpenGameSpaces());
-        games.removeIf((gameSpace -> !gameSpace.getWhitelist().isEmpty() && !gameSpace.isPlayerInWhitelist(PlayerRef.of(this.player))));
+        games.removeIf((gameSpace -> !gameSpace.isPlayerAllowed(PlayerRef.of(this.player))));
         games.sort(Comparator.comparingInt(space -> -space.getPlayers().size()));
 
         int limit = this.size;

--- a/src/main/java/xyz/nucleoid/plasmid/impl/command/ui/GameJoinUi.java
+++ b/src/main/java/xyz/nucleoid/plasmid/impl/command/ui/GameJoinUi.java
@@ -5,6 +5,7 @@ import eu.pb4.sgui.api.elements.GuiElement;
 import eu.pb4.sgui.api.gui.SimpleGui;
 import xyz.nucleoid.plasmid.api.game.GameSpace;
 import xyz.nucleoid.plasmid.api.game.config.GameConfig;
+import xyz.nucleoid.plasmid.api.util.PlayerRef;
 import xyz.nucleoid.plasmid.impl.game.manager.GameSpaceManagerImpl;
 import xyz.nucleoid.plasmid.impl.game.manager.ManagedGameSpace;
 import xyz.nucleoid.plasmid.api.game.player.GamePlayerJoiner;
@@ -64,6 +65,7 @@ public class GameJoinUi extends SimpleGui {
         int gameI = 0;
 
         var games = new ArrayList<>(GameSpaceManagerImpl.get().getOpenGameSpaces());
+        games.removeIf((gameSpace -> !gameSpace.getWhitelist().isEmpty() && !gameSpace.isPlayerInWhitelist(PlayerRef.of(this.player))));
         games.sort(Comparator.comparingInt(space -> -space.getPlayers().size()));
 
         int limit = this.size;

--- a/src/main/java/xyz/nucleoid/plasmid/impl/game/manager/ManagedGameSpace.java
+++ b/src/main/java/xyz/nucleoid/plasmid/impl/game/manager/ManagedGameSpace.java
@@ -25,9 +25,8 @@ import xyz.nucleoid.plasmid.impl.player.LocalJoinOffer;
 import xyz.nucleoid.plasmid.impl.Plasmid;
 import xyz.nucleoid.plasmid.api.event.GameEvents;
 
-import java.util.LinkedHashMap;
+import java.util.ArrayList;
 import java.util.Map;
-import java.util.UUID;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
 
@@ -40,7 +39,7 @@ public final class ManagedGameSpace implements GameSpace {
     private final ManagedGameSpacePlayers players;
     private final ManagedGameSpaceLevels worlds;
 
-    private final LinkedHashMap<UUID, Predicate<PlayerRef>> playerFilters = new LinkedHashMap<>();
+    private final ArrayList<Predicate<PlayerRef>> playerFilters = new ArrayList<>();
     private final GameLifecycle lifecycle = new GameLifecycle();
 
     private final long openTime;
@@ -152,25 +151,24 @@ public final class ManagedGameSpace implements GameSpace {
     }
 
     @Override
-    public LinkedHashMap<UUID, Predicate<PlayerRef>> getPlayerFilters() {
+    public ArrayList<Predicate<PlayerRef>> getPlayerFilters() {
         return this.playerFilters;
     }
 
     @Override
-    public UUID addPlayerFilter(Predicate<PlayerRef> filter) {
-        UUID uuid = UUID.randomUUID();
-        this.playerFilters.put(uuid, filter);
-        return uuid;
+    public Predicate<PlayerRef> addPlayerFilter(Predicate<PlayerRef> filter) {
+        this.playerFilters.add(filter);
+        return filter;
     }
 
     @Override
-    public void removePlayerFilter(UUID uuid) {
-        this.playerFilters.remove(uuid);
+    public void removePlayerFilter(Predicate<PlayerRef> filter) {
+        this.playerFilters.remove(filter);
     }
 
     @Override
     public boolean isPlayerAllowed(PlayerRef player) {
-        for (Predicate<PlayerRef> playerFilter : this.playerFilters.values()) {
+        for (Predicate<PlayerRef> playerFilter : this.playerFilters) {
             if (!playerFilter.test(player)) {
                 return false;
             }

--- a/src/main/java/xyz/nucleoid/plasmid/impl/game/manager/ManagedGameSpace.java
+++ b/src/main/java/xyz/nucleoid/plasmid/impl/game/manager/ManagedGameSpace.java
@@ -8,6 +8,7 @@ import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.level.Level;
 import org.jetbrains.annotations.Nullable;
 import xyz.nucleoid.fantasy.RuntimeLevelHandle;
@@ -27,6 +28,7 @@ import xyz.nucleoid.plasmid.api.event.GameEvents;
 import java.util.ArrayList;
 import java.util.Map;
 import java.util.function.Consumer;
+import java.util.function.Predicate;
 
 public final class ManagedGameSpace implements GameSpace {
     private final MinecraftServer server;
@@ -37,8 +39,7 @@ public final class ManagedGameSpace implements GameSpace {
     private final ManagedGameSpacePlayers players;
     private final ManagedGameSpaceLevels worlds;
 
-    private final ArrayList<PlayerRef> whitelistedPlayers = new ArrayList<>();
-
+    private final ArrayList<Predicate<PlayerRef>> playerFilters = new ArrayList<>();
     private final GameLifecycle lifecycle = new GameLifecycle();
 
     private final long openTime;
@@ -150,16 +151,26 @@ public final class ManagedGameSpace implements GameSpace {
     }
 
     @Override
-    public ArrayList<PlayerRef> getWhitelist() { return this.whitelistedPlayers; }
+    public ArrayList<Predicate<PlayerRef>> getPlayerFilters() {
+        return this.playerFilters;
+    }
 
     @Override
-    public boolean isPlayerInWhitelist(PlayerRef playerRef) { return this.whitelistedPlayers.contains(playerRef); }
+    public void addPlayerFilter(Predicate<PlayerRef> filter) {
+        this.playerFilters.add(filter);
+    }
 
     @Override
-    public void addPlayerToWhitelist(PlayerRef playerRef) { this.whitelistedPlayers.add(playerRef); }
-
-    @Override
-    public void removePlayerFromWhitelist(PlayerRef playerRef) { this.whitelistedPlayers.remove(playerRef); }
+    public boolean isPlayerAllowed(PlayerRef player) {
+        boolean isAllowed = true;
+        for (Predicate<PlayerRef> playerFilter : this.playerFilters) {
+            if (!playerFilter.test(player)) {
+                isAllowed = false;
+                break;
+            }
+        }
+        return isAllowed;
+    }
 
     @Override
     public ManagedGameSpaceLevels getLevels() {

--- a/src/main/java/xyz/nucleoid/plasmid/impl/game/manager/ManagedGameSpace.java
+++ b/src/main/java/xyz/nucleoid/plasmid/impl/game/manager/ManagedGameSpace.java
@@ -25,8 +25,9 @@ import xyz.nucleoid.plasmid.impl.player.LocalJoinOffer;
 import xyz.nucleoid.plasmid.impl.Plasmid;
 import xyz.nucleoid.plasmid.api.event.GameEvents;
 
-import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.UUID;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
 
@@ -39,7 +40,7 @@ public final class ManagedGameSpace implements GameSpace {
     private final ManagedGameSpacePlayers players;
     private final ManagedGameSpaceLevels worlds;
 
-    private final ArrayList<Predicate<PlayerRef>> playerFilters = new ArrayList<>();
+    private final LinkedHashMap<UUID, Predicate<PlayerRef>> playerFilters = new LinkedHashMap<>();
     private final GameLifecycle lifecycle = new GameLifecycle();
 
     private final long openTime;
@@ -151,25 +152,30 @@ public final class ManagedGameSpace implements GameSpace {
     }
 
     @Override
-    public ArrayList<Predicate<PlayerRef>> getPlayerFilters() {
+    public LinkedHashMap<UUID, Predicate<PlayerRef>> getPlayerFilters() {
         return this.playerFilters;
     }
 
     @Override
-    public void addPlayerFilter(Predicate<PlayerRef> filter) {
-        this.playerFilters.add(filter);
+    public UUID addPlayerFilter(Predicate<PlayerRef> filter) {
+        UUID uuid = UUID.randomUUID();
+        this.playerFilters.put(uuid, filter);
+        return uuid;
+    }
+
+    @Override
+    public void removePlayerFilter(UUID uuid) {
+        this.playerFilters.remove(uuid);
     }
 
     @Override
     public boolean isPlayerAllowed(PlayerRef player) {
-        boolean isAllowed = true;
-        for (Predicate<PlayerRef> playerFilter : this.playerFilters) {
+        for (Predicate<PlayerRef> playerFilter : this.playerFilters.values()) {
             if (!playerFilter.test(player)) {
-                isAllowed = false;
-                break;
+                return false;
             }
         }
-        return isAllowed;
+        return true;
     }
 
     @Override

--- a/src/main/java/xyz/nucleoid/plasmid/impl/game/manager/ManagedGameSpace.java
+++ b/src/main/java/xyz/nucleoid/plasmid/impl/game/manager/ManagedGameSpace.java
@@ -17,11 +17,14 @@ import xyz.nucleoid.plasmid.api.game.event.GameActivityEvents;
 import xyz.nucleoid.plasmid.api.game.event.GamePlayerEvents;
 import xyz.nucleoid.plasmid.api.game.player.JoinAcceptorResult;
 import xyz.nucleoid.plasmid.api.game.player.JoinOfferResult;
+import xyz.nucleoid.plasmid.api.game.player.PlayerSet;
+import xyz.nucleoid.plasmid.api.util.PlayerRef;
 import xyz.nucleoid.plasmid.impl.player.LocalJoinAcceptor;
 import xyz.nucleoid.plasmid.impl.player.LocalJoinOffer;
 import xyz.nucleoid.plasmid.impl.Plasmid;
 import xyz.nucleoid.plasmid.api.event.GameEvents;
 
+import java.util.ArrayList;
 import java.util.Map;
 import java.util.function.Consumer;
 
@@ -33,6 +36,8 @@ public final class ManagedGameSpace implements GameSpace {
 
     private final ManagedGameSpacePlayers players;
     private final ManagedGameSpaceLevels worlds;
+
+    private final ArrayList<PlayerRef> whitelistedPlayers = new ArrayList<>();
 
     private final GameLifecycle lifecycle = new GameLifecycle();
 
@@ -143,6 +148,18 @@ public final class ManagedGameSpace implements GameSpace {
     public ManagedGameSpacePlayers getPlayers() {
         return this.players;
     }
+
+    @Override
+    public ArrayList<PlayerRef> getWhitelist() { return this.whitelistedPlayers; }
+
+    @Override
+    public boolean isPlayerInWhitelist(PlayerRef playerRef) { return this.whitelistedPlayers.contains(playerRef); }
+
+    @Override
+    public void addPlayerToWhitelist(PlayerRef playerRef) { this.whitelistedPlayers.add(playerRef); }
+
+    @Override
+    public void removePlayerFromWhitelist(PlayerRef playerRef) { this.whitelistedPlayers.remove(playerRef); }
 
     @Override
     public ManagedGameSpaceLevels getLevels() {

--- a/src/main/java/xyz/nucleoid/plasmid/impl/game/manager/ManagedGameSpace.java
+++ b/src/main/java/xyz/nucleoid/plasmid/impl/game/manager/ManagedGameSpace.java
@@ -25,8 +25,7 @@ import xyz.nucleoid.plasmid.impl.player.LocalJoinOffer;
 import xyz.nucleoid.plasmid.impl.Plasmid;
 import xyz.nucleoid.plasmid.api.event.GameEvents;
 
-import java.util.ArrayList;
-import java.util.Map;
+import java.util.*;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
 
@@ -151,8 +150,8 @@ public final class ManagedGameSpace implements GameSpace {
     }
 
     @Override
-    public ArrayList<Predicate<PlayerRef>> getPlayerFilters() {
-        return this.playerFilters;
+    public List<Predicate<PlayerRef>> getPlayerFilters() {
+        return Collections.unmodifiableList(this.playerFilters);
     }
 
     @Override

--- a/src/main/resources/data/plasmid/lang/en_us.json
+++ b/src/main/resources/data/plasmid/lang/en_us.json
@@ -35,6 +35,7 @@
   "text.plasmid.game.join.error": "An unexpected exception occurred while joining game!",
   "text.plasmid.game.join.no_game_open": "No games are open!",
   "text.plasmid.game.join.party.error": "%s players were unable to join this game!",
+  "text.plasmid.game.join.party.error.private": "Not all players are in this game's whitelist!",
   "text.plasmid.game.leave": "%s has left the game lobby!",
   "text.plasmid.game.leave.spectate": "%s is no longer spectating the game lobby!",
   "text.plasmid.game.kick": "%s was kicked from the game!",

--- a/src/main/resources/data/plasmid/lang/en_us.json
+++ b/src/main/resources/data/plasmid/lang/en_us.json
@@ -35,7 +35,7 @@
   "text.plasmid.game.join.error": "An unexpected exception occurred while joining game!",
   "text.plasmid.game.join.no_game_open": "No games are open!",
   "text.plasmid.game.join.party.error": "%s players were unable to join this game!",
-  "text.plasmid.game.join.party.error.private": "Not all players are in this game's whitelist!",
+  "text.plasmid.game.join.party.error.not_allowed": "Not all players are allowed to join this game!",
   "text.plasmid.game.leave": "%s has left the game lobby!",
   "text.plasmid.game.leave.spectate": "%s is no longer spectating the game lobby!",
   "text.plasmid.game.kick": "%s was kicked from the game!",


### PR DESCRIPTION
This PR adds support for private games within the plasmid framework. This is allowed by adding whitelists to gamespaces, which can be added to or removed to allow players to play with only their friends. Work has also been done to make sure that the Waiting Lobby is aware of this, and automatically starts as soon as all whitelisted players are in the lobby (if the game allows for it within the player count). If a party joins that has one or more players not whitelisted, then all members cannot join together.
This pr is meant to be used in conjunction with NucleoidMC/game-parties#30 to ensure players have a way to set their whitelist properly.