### PR TITLE
QOL: Try joining gamespace as the opposite intent if the first one fails

### DIFF
--- a/src/main/java/xyz/nucleoid/plasmid/impl/command/GameCommand.java
+++ b/src/main/java/xyz/nucleoid/plasmid/impl/command/GameCommand.java
@@ -302,7 +302,21 @@ public final class GameCommand {
     private static void tryJoinGame(ServerPlayer player, GameSpace gameSpace, JoinIntent intent) {
         var result = GamePlayerJoiner.tryJoin(player, gameSpace, intent);
         if (result.isError()) {
-            player.sendSystemMessage(result.errorCopy().withStyle(ChatFormatting.RED));
+            JoinIntent newIntent;
+            if (intent.equals(JoinIntent.SPECTATE)) {
+                newIntent = JoinIntent.PLAY;
+            } else {
+                newIntent = JoinIntent.SPECTATE;
+            }
+            var result2 = GamePlayerJoiner.tryJoin(player, gameSpace, newIntent);
+            if (result2.isError()) {
+                player.sendSystemMessage(result2.errorCopy().withStyle(ChatFormatting.RED));
+            } else {
+                player.sendSystemMessage(Component.translatable("text.plasmid.join_result.switched_intent",
+                        (newIntent.equals(JoinIntent.SPECTATE) ? "player" : "spectator"),
+                        (newIntent.equals(JoinIntent.SPECTATE) ? "spectator" : "player")
+                ));
+            }
         }
     }
 

--- a/src/main/resources/data/plasmid/lang/en_us.json
+++ b/src/main/resources/data/plasmid/lang/en_us.json
@@ -77,6 +77,7 @@
   "text.plasmid.join_result.not_allowed": "You are not allowed to join this game!",
   "text.plasmid.join_result.spectators_only": "You are not allowed to participate in this game!",
   "text.plasmid.join_result.participants_only": "You are not allowed to spectate this game!",
+  "text.plasmid.join_result.switched_intent": "You were not able to join as a %s and joined as a %s",
   "text.plasmid.map_workspace.workspace_not_found": "Map with id '%s' was not found!",
   "text.plasmid.map.bounds.get": "The bounds for the workspace are %s to %s",
   "text.plasmid.map.bounds.set": "Updated bounds for workspace",


### PR DESCRIPTION
This removes the friction when a game is already running and only accepts spectators, but players still try joining with play intent without knowing.