### PR TITLE
Fix the player not being able to harm himself while on a team

### DIFF
--- a/src/main/java/xyz/nucleoid/plasmid/api/game/common/team/TeamManager.java
+++ b/src/main/java/xyz/nucleoid/plasmid/api/game/common/team/TeamManager.java
@@ -339,7 +339,7 @@ public final class TeamManager implements Iterable<GameTeam> {
             var playerTeam = this.teamFor(player);
             var attackerTeam = this.teamFor(attacker);
 
-            if (playerTeam != null && playerTeam == attackerTeam && !this.getTeamConfig(playerTeam).friendlyFire()) {
+            if (playerTeam != null && playerTeam == attackerTeam && !player.equals(attacker) && !this.getTeamConfig(playerTeam).friendlyFire()) {
                 return EventResult.DENY;
             }
         }


### PR DESCRIPTION
This fixes scenarios where a player previously wasn't able to harm himself if they were on a team. This usually happens in games like skywars, where players could blow themselves up with TNT but not take damage because they were both the attacker and receiver (which would get registered as being the same team).