### PR TITLE
Check if all players that *can* join are in the waiting lobby

### DIFF
--- a/src/main/java/xyz/nucleoid/plasmid/api/game/common/GameWaitingLobby.java
+++ b/src/main/java/xyz/nucleoid/plasmid/api/game/common/GameWaitingLobby.java
@@ -437,6 +437,17 @@ public final class GameWaitingLobby {
             return true;
         }
 
+        // if all filtered players are in this lobby
+        int playersThatCanJoin = 0;
+        for (ServerPlayer player : server.getPlayerList().getPlayers()) {
+            if (this.gameSpace.isPlayerAllowed(PlayerRef.of(player))) {
+                playersThatCanJoin++;
+            }
+        }
+        if (count >= playersThatCanJoin) {
+            return true;
+        }
+
         // if there are no players outside of a game on the server
         for (var world : server.getAllLevels()) {
             if (hasActivePlayer(world) && !GameSpaceManagerImpl.get().hasGame(world)) {


### PR DESCRIPTION
Fixes the issue where a private game might not be considered as full even if all the players that *can* join are in the waiting lobby